### PR TITLE
fix(types): add missing menuItemLimit to TributeOptions

### DIFF
--- a/src/lib/actions/autocomplete.ts
+++ b/src/lib/actions/autocomplete.ts
@@ -3,6 +3,7 @@ import { createRxNostr, createRxOneshotReq, filterBy, verify, latestEach } from 
 import { map, toArray } from 'rxjs';
 import { encode } from 'html-entities';
 import { browser } from '$app/environment';
+import type { TributeOptions } from 'tributejs';
 
 export type Opts = {
   containerElement: HTMLElement;
@@ -28,7 +29,9 @@ export const autocomplete = (node: HTMLElement, opts: Partial<Opts>) => {
       const rxNostr = createRxNostr();
       rxNostr.switchRelays(opts.relays ?? []);
 
-      const tribute = new Tribute({
+      // menuItemLimit is a supported Tribute option that's missing from the bundled types
+      // (https://github.com/zurb/tribute/blob/5.1.3/src/Tribute.js#L26)
+      const tributeOptions: TributeOptions<Item> & { menuItemLimit: number } = {
         trigger: `${opts.prefix}@`,
         menuContainer: opts.containerElement,
         requireLeadingSpace: false,
@@ -82,7 +85,8 @@ export const autocomplete = (node: HTMLElement, opts: Partial<Opts>) => {
               callback(values);
             });
         },
-      });
+      };
+      const tribute = new Tribute(tributeOptions);
 
       tribute.attach(node);
 


### PR DESCRIPTION
## Summary
- tributejs 5.1.3's bundled `.d.ts` doesn't declare `menuItemLimit`, even though it's a real, supported runtime option (see `node_modules/tributejs/src/Tribute.js`).
- This causes `svelte-check` to fail on the options object literal passed to `new Tribute()` in `src/lib/actions/autocomplete.ts`.
- Type the options object explicitly as `TributeOptions<Item> & { menuItemLimit: number }` so the extra property is recognized without touching `node_modules` or asserting away the check entirely.
- Found while preparing to add a CI workflow that runs `npm run check` — this was the last error blocking a clean run.

## Test plan
- [x] `npm run check` — 0 errors (previously 1)
- [x] `npm run lint`
- [x] `npm run build`