### PR TITLE
chore(deps): bump @fortawesome packages to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "dependencies": {
         "@floating-ui/dom": "^1.8.0",
-        "@fortawesome/fontawesome-svg-core": "^6.7.2",
-        "@fortawesome/free-brands-svg-icons": "^6.7.2",
-        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/fontawesome-svg-core": "^7.3.0",
+        "@fortawesome/free-brands-svg-icons": "^7.3.0",
+        "@fortawesome/free-solid-svg-icons": "^7.3.0",
         "@fortawesome/svelte-fontawesome": "^0.2.4",
         "html-entities": "^2.6.0",
         "linkify-html": "^4.3.3",
@@ -637,44 +637,45 @@
       "license": "MIT"
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
-      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
+      "integrity": "sha512-X/vND0Y1l9fVJ9O79UgtZnXSpz4aNF3bXlDxiJAEAm6kgeSftp9wjjBPgqzazJV8YlmxfRoeXNfSCJ48sf/Hhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
-      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
+      "integrity": "sha512-MFbTNLDWkLJwbozDvHOZ7hwyDjQcBMBattlcOQ6ZmV5YD9bBrqdl1rNtmVjQ/lzqveXXX3sMz2Ew6fAgXoxmkw==",
       "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
+        "@fortawesome/fontawesome-common-types": "7.3.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.7.2.tgz",
-      "integrity": "sha512-zu0evbcRTgjKfrr77/2XX+bU+kuGfjm0LbajJHVIgBWNIDzrhpRxiCPNT8DW5AdmSsq7Mcf9D1bH0aSeSUSM+Q==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.3.0.tgz",
+      "integrity": "sha512-W6C9ZbPWpwcUycq6U90lVbvWTrEnr01Td2x5jlO8fOtvww4kqDBMSmZqXQCc6FIIJD4kTH6G1MBRExAaSXz3yg==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
+        "@fortawesome/fontawesome-common-types": "7.3.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
-      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.0.tgz",
+      "integrity": "sha512-YxI/CuwWeI3nPIoYU//vkDS+3ige/67DPZ6XwMATpYEFESzO9L8zfJOKllGRgIlpT/uebrZCcvAzp3peD7GmTw==",
       "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
+        "@fortawesome/fontawesome-common-types": "7.3.0"
       },
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   "type": "module",
   "dependencies": {
     "@floating-ui/dom": "^1.8.0",
-    "@fortawesome/fontawesome-svg-core": "^6.7.2",
-    "@fortawesome/free-brands-svg-icons": "^6.7.2",
-    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/fontawesome-svg-core": "^7.3.0",
+    "@fortawesome/free-brands-svg-icons": "^7.3.0",
+    "@fortawesome/free-solid-svg-icons": "^7.3.0",
     "@fortawesome/svelte-fontawesome": "^0.2.4",
     "html-entities": "^2.6.0",
     "linkify-html": "^4.3.3",


### PR DESCRIPTION
## Summary
Phase 3 of the dependency modernization plan. Bumps `@fortawesome/fontawesome-svg-core`, `@fortawesome/free-brands-svg-icons`, and `@fortawesome/free-solid-svg-icons` from `6.7.2` to `7.3.0`, keeping all three on the same major (their previous version skew across these three packages was the root cause fixed in #299).

Font Awesome 7's documented breaking changes (HTML class syntax, `fa-fw` removal, Sass namespace changes) are all in the CSS/webfont and Sass tooling — this project consumes icons purely as SVG+JS objects via `@fortawesome/svelte-fontawesome` (whose installed `0.2.4` already declares `@fortawesome/fontawesome-svg-core: "~1 || ~6 || ~7"` as a peer dependency), so none of that applies. Checked every icon name used in the codebase (`faBars`, `faSearch`, `faGithub`, `faBolt`, `faEllipsisVertical`) — none were renamed in v7.

## Test plan
- [x] `npm run lint`
- [x] `npm run check` — 0 errors
- [x] `npm run build`
- [x] `npm run dev` — visually confirmed icons render correctly (bars, magnifying-glass, github, bolt all present with correct `data-prefix`/`data-icon` in rendered HTML)