### PR TITLE
chore(deps): bump rx-nostr to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,13 @@
         "@fortawesome/free-brands-svg-icons": "^7.3.0",
         "@fortawesome/free-solid-svg-icons": "^7.3.0",
         "@fortawesome/svelte-fontawesome": "^0.2.4",
+        "@rx-nostr/crypto": "^3.1.6",
         "html-entities": "^2.6.0",
         "linkify-html": "^4.3.3",
         "linkify-plugin-mention": "^4.3.3",
         "linkifyjs": "^4.3.3",
         "nostr-tools": "^2.23.9",
-        "rx-nostr": "^1.3.1",
+        "rx-nostr": "^3.7.5",
         "tributejs": "^5.1.3",
         "url-regex-safe": "^4.0.0"
       },
@@ -791,22 +792,27 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
-      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.3.1"
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1071,16 +1077,50 @@
         "win32"
       ]
     },
-    "node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
+    "node_modules/@rx-nostr/crypto": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@rx-nostr/crypto/-/crypto-3.1.6.tgz",
+      "integrity": "sha512-9KOpSxEqYIdrV7rTXImKMnlm/moDZhDZotnhW+kezbTkreQnYQJ9FPIth/ME/gXyR37LVqgRXS2FHp67WrNiHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@scure/base": "^2.0.0",
+        "@types/node": "^25.6.0",
+        "nostr-typedef": "^0.13.0"
+      },
+      "peerDependencies": {
+        "rx-nostr": "~3"
+      },
+      "peerDependenciesMeta": {
+        "rx-nostr": {
+          "optional": true
         }
-      ]
+      }
+    },
+    "node_modules/@rx-nostr/crypto/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@rx-nostr/crypto/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@scure/bip32": {
       "version": "2.0.1",
@@ -2367,17 +2407,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-url": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/nostr-tools": {
       "version": "2.23.9",
       "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.9.tgz",
@@ -2441,7 +2470,6 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/nostr-typedef/-/nostr-typedef-0.13.0.tgz",
       "integrity": "sha512-CwEC8m83FYKip4ED0nkQa+/tJQpJAKwzc7JgPsunuv26ZpwYqNfc+KvEaKCyM/q5IuKzWuSzsLFtXDfTIm2lkQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nostr-wasm": {
@@ -2907,22 +2935,30 @@
       }
     },
     "node_modules/rx-nostr": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/rx-nostr/-/rx-nostr-1.8.1.tgz",
-      "integrity": "sha512-TITUXAvw7LyhqxAYsaAjNtiCJ+NVcedA86+z8CpE4tMudtg8dokDaF+jqzXUkv+/yBwOfRDJi730cA6PICMd+w==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/rx-nostr/-/rx-nostr-3.7.5.tgz",
+      "integrity": "sha512-hmgLIVo22Q5FHfDoWugfr6SyuyeoFgrMT8bjv8LU6jE5NndwvYeZ5SfQOgLZ1p5t19PSU3PQHJBv5dhCcS8bBA==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/curves": "^1.0.0",
-        "@noble/hashes": "^1.3.0",
-        "@scure/base": "^1.1.1",
-        "normalize-url": "^8.0.0",
-        "nostr-typedef": "^0.4.0",
+        "@types/node": "^25.6.0",
+        "nostr-typedef": "^0.13.0",
         "rxjs": "^7.8.0"
       }
     },
-    "node_modules/rx-nostr/node_modules/nostr-typedef": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/nostr-typedef/-/nostr-typedef-0.4.0.tgz",
-      "integrity": "sha512-0hixsTzPHQ0EWGR592mEQFunAk3+0DkgLTXFi5emViMbSpu2f8g5mjjgEgDwjiky047dTfiVw7qMKibZrI5DfQ=="
+    "node_modules/rx-nostr/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/rx-nostr/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
     },
     "node_modules/rxjs": {
       "version": "7.8.1",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,13 @@
     "@fortawesome/free-brands-svg-icons": "^7.3.0",
     "@fortawesome/free-solid-svg-icons": "^7.3.0",
     "@fortawesome/svelte-fontawesome": "^0.2.4",
+    "@rx-nostr/crypto": "^3.1.6",
     "html-entities": "^2.6.0",
     "linkify-html": "^4.3.3",
     "linkify-plugin-mention": "^4.3.3",
     "linkifyjs": "^4.3.3",
     "nostr-tools": "^2.23.9",
-    "rx-nostr": "^1.3.1",
+    "rx-nostr": "^3.7.5",
     "tributejs": "^5.1.3",
     "url-regex-safe": "^4.0.0"
   }

--- a/src/lib/actions/autocomplete.ts
+++ b/src/lib/actions/autocomplete.ts
@@ -1,3 +1,4 @@
+import { verifier } from '@rx-nostr/crypto';
 import { encode } from 'html-entities';
 import { nip19 } from 'nostr-tools';
 import { createRxNostr, createRxOneshotReq, filterBy, latestEach, verify } from 'rx-nostr';
@@ -26,8 +27,8 @@ export const autocomplete = (node: HTMLElement, opts: Partial<Opts>) => {
 
   const asyncDisposer = import('tributejs')
     .then(({ default: Tribute }) => {
-      const rxNostr = createRxNostr();
-      rxNostr.switchRelays(opts.relays ?? []);
+      const rxNostr = createRxNostr({ verifier });
+      rxNostr.setDefaultRelays(opts.relays ?? []);
 
       // menuItemLimit is a supported Tribute option that's missing from the bundled types
       // (https://github.com/zurb/tribute/blob/5.1.3/src/Tribute.js#L26)
@@ -68,7 +69,7 @@ export const autocomplete = (node: HTMLElement, opts: Partial<Opts>) => {
             .use(req)
             .pipe(
               filterBy({ kinds: [0], search: text }),
-              verify(),
+              verify(verifier),
               latestEach(({ event }) => event.pubkey),
               map(({ event }) => event),
               toArray()

--- a/src/lib/stores/profileStore.ts
+++ b/src/lib/stores/profileStore.ts
@@ -1,3 +1,4 @@
+import { verifier } from '@rx-nostr/crypto';
 import type * as Nostr from 'nostr-typedef';
 import { createRxNostr, createRxOneshotReq, filterBy, latestEach, verify } from 'rx-nostr';
 import { map } from 'rxjs';
@@ -10,27 +11,27 @@ export const profileStore = (pubkeys: string[]): Readable<Record<string, Nostr.E
   }
 
   return readable({}, (_, update) => {
-    const rxNostr = createRxNostr();
-    rxNostr.switchRelays(['wss://relay.damus.io', 'wss://nos.lol', 'wss://yabu.me']).then(() => {
-      const req = createRxOneshotReq({
-        filters: [{ kinds: [0], authors: pubkeys, limit: pubkeys.length }],
-      });
+    const rxNostr = createRxNostr({ verifier });
+    rxNostr.setDefaultRelays(['wss://relay.damus.io', 'wss://nos.lol', 'wss://yabu.me']);
 
-      const sub = rxNostr.use(req).pipe(
-        filterBy({ kinds: [0], authors: pubkeys }),
-        verify(),
-        latestEach(({ event }) => event.pubkey),
-        map(({ event }) => event)
-      );
+    const req = createRxOneshotReq({
+      filters: [{ kinds: [0], authors: pubkeys, limit: pubkeys.length }],
+    });
 
-      sub.subscribe((event) => {
-        update(($profileMap: Record<string, Nostr.Event>) => {
-          if ($profileMap[event.pubkey]) {
-            return { ...$profileMap };
-          }
+    const sub = rxNostr.use(req).pipe(
+      filterBy({ kinds: [0], authors: pubkeys }),
+      verify(verifier),
+      latestEach(({ event }) => event.pubkey),
+      map(({ event }) => event)
+    );
 
-          return { ...$profileMap, ...Object.fromEntries([[event.pubkey, event]]) };
-        });
+    sub.subscribe((event) => {
+      update(($profileMap: Record<string, Nostr.Event>) => {
+        if ($profileMap[event.pubkey]) {
+          return { ...$profileMap };
+        }
+
+        return { ...$profileMap, ...Object.fromEntries([[event.pubkey, event]]) };
       });
     });
 


### PR DESCRIPTION
## Summary
Phase 4 of the dependency modernization plan — the riskiest phase so far since it touches core functionality (profile lookups and the `@` autocomplete). Bumps `rx-nostr` `1.3.1` → `3.7.5` and adds `@rx-nostr/crypto` (`^3.1.6`) as a new dependency.

### Why a new dependency
As of v3, `rx-nostr` no longer bundles signature verification — it's split out to `@rx-nostr/crypto` (the sibling package `rx-nostr-crypto` is npm-deprecated in favor of the scoped one). `createRxNostr()`'s default verifier now throws (`"You must give some verifier..."`) instead of silently skipping verification, so both usage sites now pass `verifier` explicitly.

### Changes in `profileStore.ts` and `autocomplete.ts`
- `createRxNostr()` → `createRxNostr({ verifier })`
- `verify()` → `verify(verifier)` — the pipe operator lost its no-arg overload
- `rxNostr.switchRelays(...)` (removed in v3) → `rxNostr.setDefaultRelays(...)`. This is synchronous (`void`, not a `Promise`), so `profileStore.ts`'s `.then(() => {...})` wrapper around it is gone too — rx-nostr queues the actual relay connection internally regardless of when `use()` is called, so nothing needed to wait for it.
- `filterBy()` and `createRxOneshotReq()` are unchanged in v3.

### Verification
Before wiring the changes into the app, I wrote standalone Node scripts (Node 26 has a native `WebSocket`) mirroring each pipeline exactly against live relays:
- `profileStore.ts`'s pattern (`authors`-filtered kind:0 lookup → `filterBy` → `verify(verifier)` → `latestEach` → `map`) — received and correctly signature-verified a real profile event.
- `autocomplete.ts`'s pattern (`search`-filtered kind:0 lookup → same pipe → `toArray()`) — received 10 real search results.

Also checked in-app: `npm run dev` + `curl '/?q=nostr'` renders real search results server-side (87 note cards).

## Test plan
- [x] `npm run lint`
- [x] `npm run check` — 0 errors
- [x] `npm run build`
- [x] Standalone scripts against live relays confirming both rx-nostr pipelines still receive and verify real events
- [x] `npm run dev` — search results page renders with real data