### PR TITLE
chore(deps): add Playwright as a manual-QA screenshot tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+/screenshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@types/url-regex-safe": "^1.0.2",
         "autoprefixer": "^10.5.2",
         "nostr-typedef": "^0.13.0",
+        "playwright": "^1.61.1",
         "postcss": "^8.5.18",
         "svelte": "^5.0.0",
         "svelte-check": "^4.7.2",
@@ -2905,6 +2906,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "biome check .",
-    "format": "biome check --write ."
+    "format": "biome check --write .",
+    "screenshot": "node scripts/screenshot.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",
@@ -23,6 +24,7 @@
     "@types/url-regex-safe": "^1.0.2",
     "autoprefixer": "^10.5.2",
     "nostr-typedef": "^0.13.0",
+    "playwright": "^1.61.1",
     "postcss": "^8.5.18",
     "svelte": "^5.0.0",
     "svelte-check": "^4.7.2",

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -1,0 +1,35 @@
+// Quick manual-QA helper: screenshot a running dev/preview server.
+//
+// Usage:
+//   npm run screenshot -- <path> [output-name]
+//
+// Examples:
+//   npm run screenshot -- /                     # screenshots/home.png
+//   npm run screenshot -- "/?q=nostr" search     # screenshots/search.png
+//
+// Requires the app to already be running (npm run dev / npm run preview).
+// Reads the base URL from BASE_URL (defaults to http://localhost:5173).
+
+import { mkdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const baseUrl = process.env.BASE_URL ?? 'http://localhost:5173';
+const path = process.argv[2] ?? '/';
+const name = process.argv[3] ?? (path.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'home');
+
+const outDir = new URL('../screenshots/', import.meta.url);
+await mkdir(outDir, { recursive: true });
+const outPath = fileURLToPath(new URL(`${name}.png`, outDir));
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+// `networkidle` never fires here: rx-nostr keeps relay WebSockets open, and
+// the dev server keeps an HMR socket open too. `load` + a short fixed wait
+// is good enough for a manual QA screenshot.
+await page.goto(new URL(path, baseUrl).toString());
+await page.waitForTimeout(1000);
+await page.screenshot({ path: outPath, fullPage: true });
+await browser.close();
+
+console.log(`saved ${outPath}`);


### PR DESCRIPTION
## Summary
Two rounds of manual browser QA on the Tailwind v4/skeleton-svelte migration (#308) found several rendering bugs (dark mode silently on, missing card backgrounds, broken vertical centering, etc.) that neither `svelte-check`/build nor SSR HTML checks could catch. Debugging with raw chromedriver/WebDriver protocol worked but was tedious (manual element-id extraction, `brew upgrade chromedriver` to match the installed Chrome, etc.); switching to Playwright for round 2 was much less friction.

- Adds `playwright` as a real devDependency (was used ad-hoc with `--no-save` during the #308 session).
- Adds `scripts/screenshot.mjs` + `npm run screenshot -- <path> [name]`: screenshots a route on an already-running dev/preview server (`BASE_URL` env var, defaults to `http://localhost:5173`). Not a test suite — just a reusable helper so the next manual QA session doesn't start from scratch.
- `/screenshots` added to `.gitignore` (output directory).

Not wired into CI or a real test suite. Per discussion, both are scoped as separate future phases in the modernization plan doc:
- **Phase 8**: component/interaction tests with Vitest + Testing Library (would have caught the Popover-not-closing and stale-pagination-query logic bugs from #308).
- **Phase 9**: visual regression tests building on this Playwright install (would have caught the CSS/theme rendering bugs from #308, which Vitest component tests can't).

## Test plan
- [x] `npm run lint`
- [x] `npm run check` — 0 errors
- [x] `npm run build`
- [x] `npx playwright install chromium` + `BASE_URL=http://localhost:5195 npm run screenshot -- / home` — confirmed it screenshots correctly