### PR TITLE
fix: resolve svelte state_referenced_locally warnings

### DIFF
--- a/src/lib/components/Alert.svelte
+++ b/src/lib/components/Alert.svelte
@@ -7,16 +7,16 @@
 
   let { variant = '', icon, children }: Props = $props();
 
-  // NOTE: Dynamic class name does not seem to work
-  let className = $state('preset-tonal-surface');
-  switch (variant) {
-    case 'warning':
-      className = 'preset-tonal-warning';
-      break;
-    case 'error':
-      className = 'preset-tonal-error';
-      break;
-  }
+  let className = $derived.by(() => {
+    switch (variant) {
+      case 'warning':
+        return 'preset-tonal-warning';
+      case 'error':
+        return 'preset-tonal-error';
+      default:
+        return 'preset-tonal-surface';
+    }
+  });
 </script>
 
 <aside class={`card p-4 flex gap-2 items-center ${className}`}>

--- a/src/lib/components/FooterItem.svelte
+++ b/src/lib/components/FooterItem.svelte
@@ -6,9 +6,11 @@
 
   let { last = false, children }: Props = $props();
 
-  const className = last
-    ? 'inline'
-    : "inline after:content-['・'] after:text-surface-300 after:dark:text-surface-600 after:ml-1";
+  let className = $derived(
+    last
+      ? 'inline'
+      : "inline after:content-['・'] after:text-surface-300 after:dark:text-surface-600 after:ml-1"
+  );
 </script>
 
 <li class={className}>

--- a/src/lib/components/NoteListItemMenu.svelte
+++ b/src/lib/components/NoteListItemMenu.svelte
@@ -11,15 +11,17 @@
 
   let { note, onAction }: Props = $props();
 
-  const npub = nip19.npubEncode(note.pubkey);
-  const noteId = nip19.noteEncode(note.id);
-  const nevent = nip19.neventEncode({
-    id: note.id,
-    author: note.pubkey,
-    kind: note.kind,
-  });
+  let npub = $derived(nip19.npubEncode(note.pubkey));
+  let noteId = $derived(nip19.noteEncode(note.id));
+  let nevent = $derived(
+    nip19.neventEncode({
+      id: note.id,
+      author: note.pubkey,
+      kind: note.kind,
+    })
+  );
   const nosarayDuration = 10; // mins
-  const nosaraySince = new Date((note.created_at - (nosarayDuration / 2) * 60) * 1000);
+  let nosaraySince = $derived(new Date((note.created_at - (nosarayDuration / 2) * 60) * 1000));
 
   const handleCopy = (text: string) => {
     copyToClipboard(text);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { faSearch } from '@fortawesome/free-solid-svg-icons';
   import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
   import { Pagination } from '@skeletonlabs/skeleton-svelte';
+  import { untrack } from 'svelte';
 
   import { goto } from '$app/navigation';
   import { autocomplete } from '$lib/actions/autocomplete';
@@ -17,7 +18,9 @@
   let { data }: Props = $props();
 
   let inputContainer: HTMLDivElement | undefined = $state();
-  let query = data.q ?? '';
+  // Only the initial value matters here; the `$effect` below keeps this in
+  // sync with `data.q` afterwards, so `data` doesn't need to be tracked.
+  let query = untrack(() => data.q ?? '');
 
   const mattnQuery = 'from:npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6';
 


### PR DESCRIPTION
## Summary
- Fix the `state_referenced_locally` warnings that appeared in the Vercel production build after the Vite 8 / `@sveltejs/vite-plugin-svelte` 7 bump (#310) — these were previously silent because the older vite-plugin-svelte didn't emit this diagnostic.
- `Alert.svelte` was an actual bug: `variant` was read once at mount into a plain `$state`, so the class never reacted to `variant` changing afterwards. Confirmed by removing the pre-existing `// NOTE: Dynamic class name does not seem to work` comment — it now correctly renders the warning-colored background for the "No data found" alert (verified via Playwright screenshot).
- `FooterItem.svelte` / `NoteListItemMenu.svelte` had no visible symptom (their props are effectively static per instance) but are switched to `$derived` for correctness.
- `+page.svelte`'s `query` is intentionally a one-time initial value that an existing `$effect` keeps in sync afterwards, so it's wrapped in `untrack()` instead, preserving the exact prior behavior while telling the compiler this is intentional.

## Test plan
- [x] `npm run build` — no more `state_referenced_locally` warnings
- [x] `npm run lint` — 0 errors (8 pre-existing unrelated warnings)
- [x] `npm run check` — 0 errors, 0 warnings
- [x] Verified via Playwright against the production preview build: `Alert` now shows the warning-colored background for "No data found", footer separators still render correctly, search/query behavior unchanged