### PR TITLE
fix: resolve biome lint warnings

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -16,6 +16,7 @@
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
+        // biome-ignore lint/complexity/noArguments: keep Google's official gtag.js boilerplate as-is
         dataLayer.push(arguments);
       }
       gtag('js', new Date());

--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -20,8 +20,8 @@
 
   let profileContent = $derived(profile ? JSON.parse(profile.content) : undefined);
   let displayName =
-    $derived(profileContent && profileContent.display_name ? profileContent.display_name : undefined);
-  let profileName = $derived(profileContent && profileContent.name ? profileContent.name : undefined);
+    $derived(profileContent?.display_name ? profileContent.display_name : undefined);
+  let profileName = $derived(profileContent?.name ? profileContent.name : undefined);
   let nameOrPubkey = $derived(displayName ?? profileName ?? shorten(note.pubkey));
 
   let noteContent = $derived(note.content

--- a/src/lib/helpers/parseQuery.ts
+++ b/src/lib/helpers/parseQuery.ts
@@ -4,36 +4,35 @@ import type { SearchQuery } from '$lib/types';
 const filters = ['since', 'until', 'from'];
 
 export function parseQuery(query: string): Partial<SearchQuery> {
-  return query.split(' ').reduce(
-    (acc: Partial<SearchQuery>, keyword: string) => {
-      const [filter, ...parameters] = keyword.split(':');
+  const result: Partial<SearchQuery> = {};
 
-      const parameter = parameters.join(':');
-      if (filters.includes(filter) && parameter !== '') {
-        switch (filter) {
-          case 'since':
-            return { ...acc, since: new Date(parameter) };
-          case 'until':
-            return { ...acc, until: new Date(parameter) };
-          case 'from': {
-            try {
-              const { data } = nip19.decode(parameter);
-              return { ...acc, pubkey: data as string };
-            } catch {
-              return acc; // NOTE: ignore invalid pubkey
-            }
+  for (const keyword of query.split(' ')) {
+    const [filter, ...parameters] = keyword.split(':');
+    const parameter = parameters.join(':');
+
+    if (filters.includes(filter) && parameter !== '') {
+      switch (filter) {
+        case 'since':
+          result.since = new Date(parameter);
+          continue;
+        case 'until':
+          result.until = new Date(parameter);
+          continue;
+        case 'from':
+          try {
+            const { data } = nip19.decode(parameter);
+            result.pubkey = data as string;
+          } catch {
+            // NOTE: ignore invalid pubkey
           }
-          default:
-            throw new Error('unexpected');
-        }
+          continue;
+        default:
+          throw new Error('unexpected');
       }
+    }
 
-      if (acc.query) {
-        return { ...acc, query: `${acc.query} ${keyword}` };
-      }
+    result.query = result.query ? `${result.query} ${keyword}` : keyword;
+  }
 
-      return { ...acc, query: keyword };
-    },
-    {} as Partial<SearchQuery>
-  );
+  return result;
 }


### PR DESCRIPTION
## Summary
- Rewrite `parseQuery`'s `reduce` + object-spread accumulator as a `for...of` loop with direct mutation, eliminating five `lint/performance/noAccumulatingSpread` warnings (avoids O(n^2) behavior)
- Simplify `NoteListItem`'s profile field access with optional chaining, resolving two `lint/complexity/useOptionalChain` warnings
- Add a `biome-ignore` comment for `lint/complexity/noArguments` on the vendored Google gtag.js snippet in `app.html`, since it's kept verbatim from Google's official docs

## Test plan
- [x] `npx biome check .` reports no warnings
- [x] `npm test` — all 23 tests pass, including `parseQuery.test.ts`'s 6 cases
- [x] `npm run check` (svelte-check) reports 0 errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)