### PR TITLE
ci: fail lint on biome warnings, not just errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "biome check .",
+    "lint": "biome check --error-on-warnings .",
     "format": "biome check --write .",
     "screenshot": "node scripts/screenshot.mjs",
     "test": "vitest run"


### PR DESCRIPTION
## Summary
- `biome check` exits `0` even when it reports warnings (only actual errors trigger a non-zero exit), so the `noAccumulatingSpread`/`useOptionalChain` warnings fixed in #314 could have been merged without CI ever catching them
- Add `--error-on-warnings` to the `lint` script (`biome check --error-on-warnings .`) run by CI, so any diagnostic — warning or error — now fails the build

## Test plan
- [x] Verified `biome check --error-on-warnings .` exits non-zero against a scratch file with a known warning-level rule violation
- [x] `npm run lint` passes locally (repo currently has zero biome diagnostics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)