### PR TITLE
fix: remove url-regex-safe to eliminate re2 build warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
         "linkifyjs": "^4.3.3",
         "nostr-tools": "^2.23.9",
         "rx-nostr": "^3.7.5",
-        "tributejs": "^5.1.3",
-        "url-regex-safe": "^4.0.0"
+        "tributejs": "^5.1.3"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.3",
@@ -35,7 +34,6 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.4.2",
         "@types/node": "^26.1.1",
-        "@types/url-regex-safe": "^1.0.2",
         "jsdom": "^29.1.1",
         "msw": "^2.15.0",
         "nostr-typedef": "^0.13.0",
@@ -1923,13 +1921,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
-    "node_modules/@types/url-regex-safe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/url-regex-safe/-/url-regex-safe-1.0.2.tgz",
-      "integrity": "sha512-Ro+qmzg7SomSd4uHMCPzv0JwXtAK0gMnB0CvnFErTGFFw+Lndzt1RZS/Yj2yzrdv4h5SZPohdGPA6q/F0TUacw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -3142,15 +3133,6 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4384,15 +4366,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tlds": {
-      "version": "1.261.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
-      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
-      "license": "MIT",
-      "bin": {
-        "tlds": "bin.js"
-      }
-    },
     "node_modules/tldts": {
       "version": "7.4.8",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
@@ -4516,27 +4489,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
-      }
-    },
-    "node_modules/url-regex-safe": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/url-regex-safe/-/url-regex-safe-4.0.0.tgz",
-      "integrity": "sha512-BrnFCWKNFrFnRzKD66NtJqQepfJrUHNPvPxE5y5NSAhXBb4OlobQjt7907Jm4ItPiXaeX+dDWMkcnOd4jR9N8A==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-regex": "4.3.0",
-        "tlds": "^1.242.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "re2": "^1.20.1"
-      },
-      "peerDependenciesMeta": {
-        "re2": {
-          "optional": true
-        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.4.2",
     "@types/node": "^26.1.1",
-    "@types/url-regex-safe": "^1.0.2",
     "jsdom": "^29.1.1",
     "msw": "^2.15.0",
     "nostr-typedef": "^0.13.0",
@@ -53,7 +52,6 @@
     "linkifyjs": "^4.3.3",
     "nostr-tools": "^2.23.9",
     "rx-nostr": "^3.7.5",
-    "tributejs": "^5.1.3",
-    "url-regex-safe": "^4.0.0"
+    "tributejs": "^5.1.3"
   }
 }

--- a/src/lib/actions/inlineImage.ts
+++ b/src/lib/actions/inlineImage.ts
@@ -1,4 +1,4 @@
-import urlRegexSafe from 'url-regex-safe';
+import { find } from 'linkifyjs';
 // import type { Action } from 'svelte/types/runtime/action';
 
 export type Opts = {
@@ -38,14 +38,11 @@ function uniq<T>(xs: T[]): T[] {
 export const inlineImage = (node: HTMLElement, opts: Partial<Opts>) => {
   const mergedOpts = { ...defaultOpts, ...opts };
 
-  const matches = node.innerHTML.matchAll(urlRegexSafe());
-  if (matches === null) {
-    return;
-  }
+  const matches = find(node.innerHTML, 'url');
 
   // TODO: traverse innerText of children
   let text = node.innerHTML;
-  uniq([...matches].map((m) => m[0])).forEach((match) => {
+  uniq(matches.map((m) => m.value)).forEach((match) => {
     const urlString = match;
     if (!mergedOpts.validate(urlString, mergedOpts.extPattern)) {
       return;


### PR DESCRIPTION
## Summary
- Vercel builds emit `Warning: The following modules failed to locate dependencies ... node_modules/url-regex-safe/lib/index.js - re2` because `url-regex-safe` optionally `require('re2')`, a native module that isn't installed.
- `url-regex-safe` (via `inlineImage.ts`) is only used to find URLs to convert into inline `<img>` tags, and the app already depends on `linkifyjs` for the same purpose in the `linkify` action.
- Replaced the `url-regex-safe()` call with `linkifyjs`'s `find(text, 'url')`, and dropped `url-regex-safe` + `@types/url-regex-safe` from `package.json`.

## Test plan
- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm test`
- [x] `npm run build` and confirmed `.svelte-kit/output/server` no longer references `re2`/`url-regex-safe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)