### PR TITLE
chore: enable additional TypeScript strictness checks

### DIFF
--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -9,7 +9,7 @@
 
   interface Props {
     note: Nostr.Event;
-    profile: Nostr.Event;
+    profile: Nostr.Event | undefined;
   }
 
   let { note, profile }: Props = $props();

--- a/src/lib/helpers/parseQuery.ts
+++ b/src/lib/helpers/parseQuery.ts
@@ -7,7 +7,7 @@ export function parseQuery(query: string): Partial<SearchQuery> {
   const result: Partial<SearchQuery> = {};
 
   for (const keyword of query.split(' ')) {
-    const [filter, ...parameters] = keyword.split(':');
+    const [filter = '', ...parameters] = keyword.split(':');
     const parameter = parameters.join(':');
 
     if (filters.includes(filter) && parameter !== '') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,9 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
     "moduleResolution": "bundler",
     "types": ["@testing-library/jest-dom"]
   }


### PR DESCRIPTION
## Summary
- Existing `tsconfig.json` was already reasonable for this stack (TS 5.9.3, SvelteKit, `strict: true`, `moduleResolution: bundler`), but was missing a few no-cost/high-value strictness flags that TS 4.4+/5.x recommend for modern projects.
- Added `noUncheckedIndexedAccess`, `noImplicitOverride`, and `noFallthroughCasesInSwitch`.
- `noImplicitOverride` and `noFallthroughCasesInSwitch` surfaced no issues (codebase already conforms).
- `noUncheckedIndexedAccess` surfaced two real gaps, both fixed:
  - `src/lib/components/NoteListItem.svelte`: `profile` prop was typed as required `Nostr.Event`, but the component's own logic already treats it as possibly absent (`profile ? ... : undefined`), and callers can pass an unloaded profile from `profileStore`'s `Record<string, Nostr.Event>` lookup. Typed as `Nostr.Event | undefined` to match actual usage.
  - `src/lib/helpers/parseQuery.ts`: destructuring `keyword.split(':')` into `[filter, ...parameters]` is technically `string | undefined` for `filter`. Added a `''` default, which is safe since `filters.includes('')` is `false`.
- Evaluated but did not adopt `exactOptionalPropertyTypes` and `noPropertyAccessFromIndexSignature`: the former only flagged a mismatch against `tributejs`'s own (non-`undefined`-aware) type declarations rather than our code, and the latter added no value beyond enforced style.

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors/warnings
- [x] `npm run lint` (biome) — passes
- [x] `npm run test` (vitest) — 23 tests passing