### PR TITLE
chore: remove unused @floating-ui/dom dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "nosey",
       "version": "0.0.1",
       "dependencies": {
-        "@floating-ui/dom": "^1.8.0",
         "@fortawesome/fontawesome-svg-core": "^7.3.0",
         "@fortawesome/free-brands-svg-icons": "^7.3.0",
         "@fortawesome/free-solid-svg-icons": "^7.3.0",
@@ -525,6 +524,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
       "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.12"
@@ -534,6 +534,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
       "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.8.0",
@@ -544,6 +545,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@fortawesome/fontawesome-common-types": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "type": "module",
   "dependencies": {
-    "@floating-ui/dom": "^1.8.0",
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "@fortawesome/free-brands-svg-icons": "^7.3.0",
     "@fortawesome/free-solid-svg-icons": "^7.3.0",


### PR DESCRIPTION
## Summary
- `@floating-ui/dom` is no longer imported anywhere in `src` — it looks like a leftover from an earlier Skeleton popover implementation.
- Skeleton's `Popover` (already used in `Header.svelte` / `NoteListItem.svelte`) is built on `@zag-js/popover`, which brings its own `@floating-ui/dom` as a transitive dependency for positioning, so nothing loses positioning support.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — succeeds
- [x] `npm run test` — 23 passed
- [x] `npm run lint` — clean