### PR TITLE
refactor: use @zag-js/popper's virtual anchor for mention menu positioning

### DIFF
--- a/src/lib/actions/autocomplete.svelte.ts
+++ b/src/lib/actions/autocomplete.svelte.ts
@@ -49,9 +49,8 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
 
   const menuProps = $state<{
     open: boolean;
-    anchorX: number;
-    anchorY: number;
     anchorElement: HTMLElement;
+    getAnchorRect: () => { x: number; y: number; width: number; height: number };
     loading: boolean;
     items: MentionItem[];
     activeIndex: number;
@@ -59,9 +58,8 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     onSelect: (item: MentionItem) => void;
   }>({
     open: false,
-    anchorX: 0,
-    anchorY: 0,
     anchorElement: node,
+    getAnchorRect: () => computeAnchorRect(),
     loading: false,
     items: [],
     activeIndex: 0,
@@ -99,6 +97,12 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     const borderLeft = Number.parseFloat(style.borderLeftWidth) || 0;
     const x = rect.left + borderLeft + paddingLeft + textWidth - input.scrollLeft;
     return { x, y: rect.bottom };
+  };
+
+  const computeAnchorRect = () => {
+    const caretIndex = node.selectionStart ?? node.value.length;
+    const { x, y } = getAnchorPosition(node, caretIndex);
+    return { x, y, width: 0, height: 0 };
   };
 
   const cancelPendingSearch = () => {
@@ -193,13 +197,6 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     node.focus();
   };
 
-  const updateAnchorPosition = () => {
-    const caretIndex = node.selectionStart ?? node.value.length;
-    const { x, y } = getAnchorPosition(node, caretIndex);
-    menuProps.anchorX = x;
-    menuProps.anchorY = y;
-  };
-
   const handleInput = () => {
     const caretIndex = node.selectionStart ?? node.value.length;
     const match = findTrigger(node.value.slice(0, caretIndex), prefix);
@@ -210,24 +207,10 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     }
 
     triggerStart = match.triggerStart;
-    updateAnchorPosition();
     menuProps.open = true;
     menuProps.activeIndex = 0;
 
     search(match.query);
-  };
-
-  // The anchor is a `position: fixed` element positioned in JS (there's no
-  // real DOM node at the caret to anchor to), so it doesn't move on its own
-  // when the page scrolls the way a normally-flowed anchor would. Without
-  // this, the menu stays glued to its last screen position instead of
-  // following the input.
-  const handleScroll = () => {
-    if (!menuProps.open) {
-      return;
-    }
-
-    updateAnchorPosition();
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
@@ -279,16 +262,12 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
   node.addEventListener('input', handleInput);
   node.addEventListener('keydown', handleKeydown);
   node.addEventListener('blur', handleBlur);
-  // `capture: true` so this also catches scrolling of ancestor containers
-  // (native `scroll` events don't bubble, only capture/target).
-  window.addEventListener('scroll', handleScroll, true);
 
   return {
     destroy() {
       node.removeEventListener('input', handleInput);
       node.removeEventListener('keydown', handleKeydown);
       node.removeEventListener('blur', handleBlur);
-      window.removeEventListener('scroll', handleScroll, true);
       cancelPendingSearch();
       unmount(menu);
       rxNostr.dispose();

--- a/src/lib/components/MentionMenu.svelte
+++ b/src/lib/components/MentionMenu.svelte
@@ -2,11 +2,12 @@
   import { Portal, usePopover } from '@skeletonlabs/skeleton-svelte';
   import type { MentionItem } from '$lib/types';
 
+  type AnchorRect = { x?: number; y?: number; width?: number; height?: number };
+
   interface Props {
     open: boolean;
     onOpenChange: (open: boolean) => void;
-    anchorX: number;
-    anchorY: number;
+    getAnchorRect: () => AnchorRect | null;
     anchorElement: HTMLElement;
     loading: boolean;
     items: MentionItem[];
@@ -17,8 +18,7 @@
   let {
     open,
     onOpenChange,
-    anchorX,
-    anchorY,
+    getAnchorRect,
     anchorElement,
     loading,
     items,
@@ -32,11 +32,22 @@
     id,
     open,
     onOpenChange: (d) => onOpenChange(d.open),
-    // Always open below the caret instead of flipping above when the list
-    // grows too tall to fit -- flipping mid-search felt inconsistent.
-    // TODO: with many results and little space below the caret, the menu
-    // can still overflow past the bottom of the viewport; not handled yet.
-    positioning: { placement: 'bottom-start', flip: false },
+    positioning: {
+      // Always open below the caret instead of flipping above when the list
+      // grows too tall to fit -- flipping mid-search felt inconsistent.
+      // TODO: with many results and little space below the caret, the menu
+      // can still overflow past the bottom of the viewport; not handled yet.
+      placement: 'bottom-start',
+      flip: false,
+      // The input has no real DOM node at the caret to anchor to, so anchor to
+      // a virtual rect computed from the caret's on-screen position instead.
+      // `animationFrame` keeps it in sync while typing or scrolling, since
+      // neither fires the resize/scroll events `autoUpdate` listens for by
+      // default for a virtual anchor.
+      getAnchorElement: () => anchorElement,
+      getAnchorRect,
+      listeners: { animationFrame: true },
+    },
     autoFocus: false,
     modal: false,
     closeOnEscape: false,
@@ -44,23 +55,9 @@
     persistentElements: [() => anchorElement],
   }));
 
-  $effect(() => {
-    // Re-read anchorX/anchorY so this effect reruns whenever they change
-    // (typing moves the caret, scrolling moves the anchor). Popover doesn't
-    // notice plain style changes on the anchor element on its own, so it
-    // needs an explicit nudge to recompute its position.
-    anchorX;
-    anchorY;
-    popover().reposition();
-  });
-
   const itemClass = 'w-full flex justify-start items-center gap-2 text-left rounded-base px-3 py-1.5';
 </script>
 
-<div
-  {...popover().getAnchorProps()}
-  style="position: fixed; left: {anchorX}px; top: {anchorY}px; width: 0; height: 0;"
-></div>
 <Portal>
   <div {...popover().getPositionerProps()}>
     <div {...popover().getContentProps()} class="card preset-tonal-surface p-4 z-[300] mt-2 shadow">

--- a/src/lib/components/MentionMenu.test.ts
+++ b/src/lib/components/MentionMenu.test.ts
@@ -15,8 +15,7 @@ const makeItem = (overrides: Partial<MentionItem> = {}): MentionItem => ({
 const baseProps = {
   open: true,
   onOpenChange: () => {},
-  anchorX: 0,
-  anchorY: 0,
+  getAnchorRect: () => ({ x: 0, y: 0, width: 0, height: 0 }),
   anchorElement: document.createElement('input'),
   onSelect: () => {},
 };


### PR DESCRIPTION
## Summary
- Replace the mention menu's manual `window` scroll listener and effect-driven `reposition()` call with `@zag-js/popper`'s built-in virtual anchor (`getAnchorElement`/`getAnchorRect`) and `autoUpdate` (`animationFrame` listener), per feedback from #319's review.
- The canvas-based caret measurement itself is unchanged (a plain `<input>` still has no native API for per-character caret position), but it's now exposed as a lazily-evaluated `getAnchorRect` callback instead of writing into reactive `anchorX`/`anchorY` state, and the synthetic `position: fixed` anchor `<div>` is removed entirely.

## Test plan
- [x] `vitest run` (36 tests, all passing)
- [x] `svelte-check` / `tsc --noEmit`
- [x] `biome check`
- [x] Manual verification in a real browser (Playwright): mention menu opens under the caret and tracks it while typing on both usage sites (main search box and Advanced Search modal's Author field), repositions correctly, and closes on Escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)