### PR TITLE
refactor: extract shared ProfileAvatar component

### DIFF
--- a/src/lib/components/MentionMenu.svelte
+++ b/src/lib/components/MentionMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Portal, usePopover } from '@skeletonlabs/skeleton-svelte';
   import type { MentionItem } from '$lib/types';
+  import ProfileAvatar from './ProfileAvatar.svelte';
 
   type AnchorRect = { x?: number; y?: number; width?: number; height?: number };
 
@@ -75,17 +76,7 @@
                 onmousedown={(e) => e.preventDefault()}
                 onclick={() => onSelect(item)}
               >
-                {#if item.picture}
-                  <img
-                    src={item.picture}
-                    class="rounded-full inline-block w-6"
-                    alt=""
-                    decoding="async"
-                    loading="lazy"
-                  />
-                {:else}
-                  <div class="inline-block w-6"></div>
-                {/if}
+                <ProfileAvatar picture={item.picture} name={item.name} class="w-6 h-6 shrink-0" />
                 <span class="truncate">{item.name}</span>
                 {#if item.nip05}
                   <span class="truncate"><code class="code">{item.nip05}</code></span>

--- a/src/lib/components/MentionMenu.test.ts
+++ b/src/lib/components/MentionMenu.test.ts
@@ -61,7 +61,8 @@ describe('MentionMenu', () => {
     const items = [makeItem({ picture: '' })];
     render(MentionMenu, { props: { ...baseProps, loading: false, items, activeIndex: 0 } });
 
-    expect(getContent()?.querySelector('img')).toBeNull();
+    expect(getContent()?.querySelector('img')).toHaveAttribute('hidden');
+    expect(getContent()?.textContent).toContain('NO');
   });
 
   it('renders an item picture as an img src, never as injected markup via the picture field', () => {

--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
   import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
-  import { Avatar, Popover, Portal } from '@skeletonlabs/skeleton-svelte';
+  import { Popover, Portal } from '@skeletonlabs/skeleton-svelte';
   import type * as Nostr from 'nostr-typedef';
   import { inlineImage } from '$lib/actions/inlineImage';
   import { linkify, linkifyOpts } from '$lib/actions/linkify';
   import NoteListItemMenu from './NoteListItemMenu.svelte';
+  import ProfileAvatar from './ProfileAvatar.svelte';
 
   interface Props {
     note: Nostr.Event;
@@ -35,10 +36,7 @@
   <div class="p-4">
     <div class="flex justify-between items-center">
       <div class="mr-2 flex-none">
-        <Avatar>
-          <Avatar.Image src={profileContent?.picture} alt="Profile picture of {nameOrPubkey}" />
-          <Avatar.Fallback>NO</Avatar.Fallback>
-        </Avatar>
+        <ProfileAvatar picture={profileContent?.picture} name={nameOrPubkey} />
       </div>
 
       <p class="flex-auto font-bold min-w-0 text-ellipsis overflow-hidden">

--- a/src/lib/components/ProfileAvatar.svelte
+++ b/src/lib/components/ProfileAvatar.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { Avatar } from '@skeletonlabs/skeleton-svelte';
+
+  interface Props {
+    picture?: string;
+    name: string;
+    class?: string;
+  }
+
+  let { picture, name, class: className }: Props = $props();
+</script>
+
+<Avatar class={className}>
+  <Avatar.Image src={picture} alt="Profile picture of {name}" />
+  <Avatar.Fallback>NO</Avatar.Fallback>
+</Avatar>


### PR DESCRIPTION
## Summary
- `MentionMenu`'s profile picture used a plain `img`/empty-`div` fallback, while `NoteListItem` used skeleton-svelte's `Avatar` with a "NO" fallback — same intent, two implementations.
- Extracted a shared `ProfileAvatar.svelte` (`Avatar` + `Avatar.Image` + `Avatar.Fallback`) and switched both components to use it.
- Updated `MentionMenu.test.ts`: `Avatar.Image` always renders an `<img>` (hidden via a `hidden` attribute until it loads, per zag-js), so the "no picture" test now checks for the hidden image + visible "NO" fallback instead of asserting no `<img>` exists.

## Test plan
- [x] `npx vitest run` — 36/36 passing
- [x] `npm run lint` / `npm run check` — clean
- [x] Verified `NoteListItem` avatar (image + fallback) visually in a real browser against live search results
- [ ] `MentionMenu` avatar could not be visually verified in-browser — the sandboxed browser's WebSocket connections to relays time out, so the mention menu never receives results. Verified via component tests instead (same `ProfileAvatar` component already confirmed working in `NoteListItem`).