### PR TITLE
refactor: use skeleton-svelte's Menu for header and note item dropdowns

### DIFF
--- a/src/lib/actions/autocomplete.svelte.ts
+++ b/src/lib/actions/autocomplete.svelte.ts
@@ -8,6 +8,17 @@ import { browser } from '$app/environment';
 import MentionMenu from '$lib/components/MentionMenu.svelte';
 import type { MentionItem } from '$lib/types';
 
+// This intentionally hand-rolls keyboard navigation instead of using
+// @skeletonlabs/skeleton-svelte's `Menu` or `Combobox` (both wrap @zag-js
+// machines):
+// - `Menu`'s keyboard handling lives on its own trigger/content DOM nodes;
+//   selecting an item highlighted via ArrowDown/Up calls `itemEl.click()` on
+//   that node, not on this action's `<input>`, so focus would have to leave
+//   the input to drive it.
+// - `Combobox` owns `inputValue`/`value` for the whole input and replaces it
+//   wholesale on selection, but here the input holds a full note being
+//   composed and only the `prefix@query` substring after the trigger should
+//   ever be replaced -- the rest of the buffer must survive untouched.
 export type Opts = {
   relays: string[];
   prefix: string;

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { faBars } from '@fortawesome/free-solid-svg-icons';
   import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
-  import { AppBar, Popover, Portal } from '@skeletonlabs/skeleton-svelte';
+  import { AppBar, Menu, Portal } from '@skeletonlabs/skeleton-svelte';
   import HeaderMenu from './HeaderMenu.svelte';
 
   let isMenuOpen = $state(false);
@@ -13,22 +13,22 @@
       <a href="/">nosey</a>
     </AppBar.Lead>
     <AppBar.Trail class="flex items-center justify-end">
-      <Popover
+      <Menu
         positioning={{ placement: 'bottom' }}
         open={isMenuOpen}
         onOpenChange={(d) => (isMenuOpen = d.open)}
       >
-        <Popover.Trigger class="btn-icon">
+        <Menu.Trigger class="btn-icon">
           <FontAwesomeIcon icon={faBars} title="Open menu" class="w-4" />
-        </Popover.Trigger>
+        </Menu.Trigger>
         <Portal>
-          <Popover.Positioner>
-            <Popover.Content class="z-20">
-              <HeaderMenu onAdvancedSearchOpen={() => (isMenuOpen = false)} />
-            </Popover.Content>
-          </Popover.Positioner>
+          <Menu.Positioner>
+            <Menu.Content class="card preset-tonal-surface p-2 w-52 z-20 shadow space-y-1">
+              <HeaderMenu />
+            </Menu.Content>
+          </Menu.Positioner>
         </Portal>
-      </Popover>
+      </Menu>
     </AppBar.Trail>
   </AppBar.Toolbar>
 </AppBar>

--- a/src/lib/components/Header.test.ts
+++ b/src/lib/components/Header.test.ts
@@ -12,34 +12,34 @@ afterEach(() => {
 });
 
 describe('Header', () => {
-  it('opens the hamburger Popover, and opening the nested Advanced Search Dialog closes it', async () => {
+  it('opens the hamburger Menu, and selecting the Advanced Search item opens the Dialog and closes the Menu', async () => {
     new WS('wss://search.nos.today');
     new WS('wss://relay.nostr.band');
 
     const { container } = render(Header);
 
-    const popoverTrigger = container.querySelector(
-      '[data-scope="popover"][data-part="trigger"]'
+    const menuTrigger = container.querySelector(
+      '[data-scope="menu"][data-part="trigger"]'
     ) as HTMLElement;
-    const popoverContent = document.querySelector(
-      '[data-scope="popover"][data-part="content"]'
+    const menuContent = document.querySelector(
+      '[data-scope="menu"][data-part="content"]'
     ) as HTMLElement;
     const dialogContent = document.querySelector(
       '[data-scope="dialog"][data-part="content"]'
     ) as HTMLElement;
 
-    expect(popoverContent).toHaveAttribute('hidden');
+    expect(menuContent).toHaveAttribute('hidden');
     expect(dialogContent).toHaveAttribute('hidden');
 
-    await fireEvent.click(popoverTrigger);
-    expect(popoverContent).not.toHaveAttribute('hidden');
+    await fireEvent.click(menuTrigger);
+    expect(menuContent).not.toHaveAttribute('hidden');
 
-    const dialogTrigger = document.querySelector(
-      '[data-scope="dialog"][data-part="trigger"]'
+    const advancedSearchItem = document.querySelector(
+      '[data-scope="menu"][data-part="item"][data-value="advanced-search"]'
     ) as HTMLElement;
-    await fireEvent.click(dialogTrigger);
+    await fireEvent.click(advancedSearchItem);
 
     expect(dialogContent).not.toHaveAttribute('hidden');
-    expect(popoverContent).toHaveAttribute('hidden');
+    expect(menuContent).toHaveAttribute('hidden');
   });
 });

--- a/src/lib/components/HeaderMenu.svelte
+++ b/src/lib/components/HeaderMenu.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
   import { faSearch } from '@fortawesome/free-solid-svg-icons';
   import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
-  import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
+  import { Dialog, Menu, Portal } from '@skeletonlabs/skeleton-svelte';
   import { goto } from '$app/navigation';
   import { buildQuery } from '$lib/helpers/buildQuery';
   import type { AdvancedSearchFormData } from '$lib/types';
   import AdvancedSearchModal from './AdvancedSearchModal.svelte';
-
-  interface Props {
-    onAdvancedSearchOpen: () => void;
-  }
-
-  let { onAdvancedSearchOpen }: Props = $props();
 
   let isAdvancedSearchOpen = $state(false);
 
@@ -22,37 +16,24 @@
     goto(`/?${new URLSearchParams({ q: query })}`);
     isAdvancedSearchOpen = false;
   };
-
-  const handleDialogOpenChange = (d: { open: boolean }) => {
-    isAdvancedSearchOpen = d.open;
-    if (d.open) {
-      onAdvancedSearchOpen();
-    }
-  };
 </script>
 
-<div class="card preset-tonal-surface p-2 w-52 z-20 shadow">
-  <ul class="space-y-1">
-    <li>
-      <Dialog open={isAdvancedSearchOpen} onOpenChange={handleDialogOpenChange}>
-        <Dialog.Trigger
-          class="block w-full text-left rounded-base px-3 py-1.5 hover:preset-tonal"
-        >
-          <FontAwesomeIcon icon={faSearch} title="Open menu" class="w-4 inline mr-2" />
-          Advanced search
-        </Dialog.Trigger>
-        <Portal>
-          <Dialog.Backdrop class="fixed inset-0 z-50 bg-surface-50-950/50" />
-          <Dialog.Positioner class="fixed inset-0 z-50 flex justify-center items-center">
-            <Dialog.Content class="w-full max-w-md mx-4">
-              <AdvancedSearchModal
-                onClose={() => (isAdvancedSearchOpen = false)}
-                onSubmit={handleSubmit}
-              />
-            </Dialog.Content>
-          </Dialog.Positioner>
-        </Portal>
-      </Dialog>
-    </li>
-  </ul>
-</div>
+<Menu.Item
+  value="advanced-search"
+  onclick={() => (isAdvancedSearchOpen = true)}
+  class="block w-full text-left rounded-base px-3 py-1.5 hover:preset-tonal"
+>
+  <FontAwesomeIcon icon={faSearch} title="Open menu" class="w-4 inline mr-2" />
+  Advanced search
+</Menu.Item>
+
+<Dialog open={isAdvancedSearchOpen} onOpenChange={(d) => (isAdvancedSearchOpen = d.open)}>
+  <Portal>
+    <Dialog.Backdrop class="fixed inset-0 z-50 bg-surface-50-950/50" />
+    <Dialog.Positioner class="fixed inset-0 z-50 flex justify-center items-center">
+      <Dialog.Content class="w-full max-w-md mx-4">
+        <AdvancedSearchModal onClose={() => (isAdvancedSearchOpen = false)} onSubmit={handleSubmit} />
+      </Dialog.Content>
+    </Dialog.Positioner>
+  </Portal>
+</Dialog>

--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
   import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
-  import { Popover, Portal } from '@skeletonlabs/skeleton-svelte';
+  import { Menu, Portal } from '@skeletonlabs/skeleton-svelte';
   import type * as Nostr from 'nostr-typedef';
   import { inlineImage } from '$lib/actions/inlineImage';
   import { linkify, linkifyOpts } from '$lib/actions/linkify';
@@ -43,22 +43,26 @@
         {nameOrPubkey}
       </p>
 
-      <Popover
+      <Menu
         positioning={{ placement: 'bottom' }}
         open={isMenuOpen}
         onOpenChange={(d) => (isMenuOpen = d.open)}
+        navigate={(d) => {
+          window.open(d.href, '_blank', 'noreferrer');
+          isMenuOpen = false;
+        }}
       >
-        <Popover.Trigger class="btn-icon flex-none">
+        <Menu.Trigger class="btn-icon flex-none">
           <FontAwesomeIcon icon={faEllipsisVertical} title="Menu" class="w-4 h-4" />
-        </Popover.Trigger>
+        </Menu.Trigger>
         <Portal>
-          <Popover.Positioner>
-            <Popover.Content class="z-20">
-              <NoteListItemMenu {note} onAction={() => (isMenuOpen = false)} />
-            </Popover.Content>
-          </Popover.Positioner>
+          <Menu.Positioner>
+            <Menu.Content class="card preset-tonal-surface p-2 w-64 z-20 shadow space-y-1">
+              <NoteListItemMenu {note} />
+            </Menu.Content>
+          </Menu.Positioner>
         </Portal>
-      </Popover>
+      </Menu>
     </div>
 
     <p

--- a/src/lib/components/NoteListItemMenu.svelte
+++ b/src/lib/components/NoteListItemMenu.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
+  import { Menu } from '@skeletonlabs/skeleton-svelte';
   import { nip19 } from 'nostr-tools';
   import type * as Nostr from 'nostr-typedef';
   import { copyToClipboard } from '$lib/helpers/copyToClipboard';
-  import ExternalLink from './ExternalLink.svelte';
 
   interface Props {
     note: Nostr.Event;
-    onAction: () => void;
   }
 
-  let { note, onAction }: Props = $props();
+  let { note }: Props = $props();
 
   let npub = $derived(nip19.npubEncode(note.pubkey));
   let noteId = $derived(nip19.noteEncode(note.id));
@@ -23,54 +22,57 @@
   const nosarayDuration = 10; // mins
   let nosaraySince = $derived(new Date((note.created_at - (nosarayDuration / 2) * 60) * 1000));
 
-  const handleCopy = (text: string) => {
-    copyToClipboard(text);
-    onAction();
-  };
-
   const itemClass = 'block w-full text-left rounded-base px-3 py-1.5 hover:preset-tonal';
 </script>
 
-<div class="card preset-tonal-surface p-2 w-64 z-20 shadow">
-  <ul class="space-y-1">
-    <li>
-      <button type="button" class={itemClass} onclick={() => handleCopy(npub)}>
-        Copy <code class="code ml-1">npub1</code>
-      </button>
-    </li>
-    <li>
-      <button type="button" class={itemClass} onclick={() => handleCopy(noteId)}>
-        Copy <code class="code mx-1">note1</code> id
-      </button>
-    </li>
-    <li>
-      <button type="button" class={itemClass} onclick={() => handleCopy(nevent)}>
-        Copy <code class="code mx-1">nevent1</code> id
-      </button>
-    </li>
-    <li>
-      <button type="button" class={itemClass} onclick={() => handleCopy(note.content)}>
-        Copy text
-      </button>
-    </li>
-    <li>
-      <ExternalLink class={itemClass} href="https://njump.me/{npub}" onclick={onAction}>
-        Open author with njump.me
-      </ExternalLink>
-    </li>
-    <li>
-      <ExternalLink class={itemClass} href="https://njump.me/{nevent}" onclick={onAction}>
-        Open note with njump.me
-      </ExternalLink>
-    </li>
-    <li>
-      <ExternalLink
-        class={itemClass}
-        href="https://nosaray.vercel.app/?since={nosaraySince.toISOString()}&dur={nosarayDuration}m"
-        onclick={onAction}
-      >
-        See posts around this on Nosaray
-      </ExternalLink>
-    </li>
-  </ul>
-</div>
+<Menu.Item value="copy-npub" onclick={() => copyToClipboard(npub)} class={itemClass}>
+  Copy <code class="code ml-1">npub1</code>
+</Menu.Item>
+<Menu.Item value="copy-note-id" onclick={() => copyToClipboard(noteId)} class={itemClass}>
+  Copy <code class="code mx-1">note1</code> id
+</Menu.Item>
+<Menu.Item value="copy-nevent-id" onclick={() => copyToClipboard(nevent)} class={itemClass}>
+  Copy <code class="code mx-1">nevent1</code> id
+</Menu.Item>
+<Menu.Item value="copy-text" onclick={() => copyToClipboard(note.content)} class={itemClass}>
+  Copy text
+</Menu.Item>
+<Menu.Item value="njump-author">
+  {#snippet element(attrs)}
+    <a
+      {...attrs as Record<string, unknown>}
+      href="https://njump.me/{npub}"
+      rel="external noreferrer"
+      target="_blank"
+      class={itemClass}
+    >
+      Open author with njump.me
+    </a>
+  {/snippet}
+</Menu.Item>
+<Menu.Item value="njump-note">
+  {#snippet element(attrs)}
+    <a
+      {...attrs as Record<string, unknown>}
+      href="https://njump.me/{nevent}"
+      rel="external noreferrer"
+      target="_blank"
+      class={itemClass}
+    >
+      Open note with njump.me
+    </a>
+  {/snippet}
+</Menu.Item>
+<Menu.Item value="nosaray">
+  {#snippet element(attrs)}
+    <a
+      {...attrs as Record<string, unknown>}
+      href="https://nosaray.vercel.app/?since={nosaraySince.toISOString()}&dur={nosarayDuration}m"
+      rel="external noreferrer"
+      target="_blank"
+      class={itemClass}
+    >
+      See posts around this on Nosaray
+    </a>
+  {/snippet}
+</Menu.Item>


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `Popover` + `<ul><li>` dropdown in `HeaderMenu`/`NoteListItemMenu` with @skeletonlabs/skeleton-svelte's `Menu`, gaining `role="menu"`/`menuitem` semantics and built-in arrow-key highlighting, Enter-to-select, and auto-close on selection
- Drop the now-redundant manual `onAction`/`onAdvancedSearchOpen` closing callbacks now that `Menu`'s `closeOnSelect` handles it
- Keep `MentionMenu`'s hand-rolled keyboard handling as-is, and document why `Menu`/`Combobox` don't fit it in `autocomplete.svelte.ts` (Menu's key handling lives on its own trigger/content nodes rather than the mention input; Combobox owns the whole input value where only the trigger substring should be replaced)

## Test plan
- [x] `vitest run` (36 tests passing, including updated `Header.test.ts` selectors for the Menu markup)
- [x] `svelte-check` / `biome check` clean
- [x] Manually verified in a running dev server via Playwright: header hamburger menu opens, ArrowDown highlights the item, Enter opens the Advanced Search dialog and closes the menu; note item menu opens, ArrowDown highlights `njump-author`, Enter opens njump.me in a new tab and closes the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)