### PR TITLE
test: stub HTMLCanvasElement.getContext to suppress jsdom warning

### DIFF
--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -11,3 +11,13 @@ class ResizeObserverStub {
 }
 
 globalThis.ResizeObserver ??= ResizeObserverStub;
+
+// jsdom doesn't implement canvas rendering, so HTMLCanvasElement#getContext
+// logs a "Not implemented" error and returns null. The autocomplete action
+// uses a canvas to measure text width and already falls back gracefully
+// when getContext returns null, but the console noise obscures real test
+// output, so stub a minimal 2D context here.
+HTMLCanvasElement.prototype.getContext = (() => ({
+  font: '',
+  measureText: (text: string) => ({ width: text.length }),
+})) as typeof HTMLCanvasElement.prototype.getContext;


### PR DESCRIPTION
## Summary
- `npm test` printed a jsdom `"Not implemented: HTMLCanvasElement's getContext() method"` warning on every run, coming from the autocomplete action's canvas-based text-width measurement (`src/lib/actions/autocomplete.svelte.ts`)
- The code already handles `getContext` returning `null` gracefully, so this was just console noise obscuring real test output
- Stub a minimal 2D context in `vitest-setup.ts`, following the same pattern already used for the `ResizeObserver` stub, instead of adding the `canvas` native npm dependency

## Test plan
- [x] `npm test` — 36 passed, no more canvas warnings in output
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx biome check vitest-setup.ts` — no lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)