### PR TITLE
feat: show toast feedback when copying note info

### DIFF
--- a/src/lib/components/NoteListItemMenu.svelte
+++ b/src/lib/components/NoteListItemMenu.svelte
@@ -2,7 +2,7 @@
   import { Menu } from '@skeletonlabs/skeleton-svelte';
   import { nip19 } from 'nostr-tools';
   import type * as Nostr from 'nostr-typedef';
-  import { copyToClipboard } from '$lib/helpers/copyToClipboard';
+  import { copyToClipboardWithToast } from '$lib/helpers/copyToClipboardWithToast';
 
   interface Props {
     note: Nostr.Event;
@@ -25,16 +25,32 @@
   const itemClass = 'block w-full text-left rounded-base px-3 py-1.5 hover:preset-tonal';
 </script>
 
-<Menu.Item value="copy-npub" onclick={() => copyToClipboard(npub)} class={itemClass}>
+<Menu.Item
+  value="copy-npub"
+  onclick={() => copyToClipboardWithToast(npub, 'npub1')}
+  class={itemClass}
+>
   Copy <code class="code ml-1">npub1</code>
 </Menu.Item>
-<Menu.Item value="copy-note-id" onclick={() => copyToClipboard(noteId)} class={itemClass}>
+<Menu.Item
+  value="copy-note-id"
+  onclick={() => copyToClipboardWithToast(noteId, 'note1 id')}
+  class={itemClass}
+>
   Copy <code class="code mx-1">note1</code> id
 </Menu.Item>
-<Menu.Item value="copy-nevent-id" onclick={() => copyToClipboard(nevent)} class={itemClass}>
+<Menu.Item
+  value="copy-nevent-id"
+  onclick={() => copyToClipboardWithToast(nevent, 'nevent1 id')}
+  class={itemClass}
+>
   Copy <code class="code mx-1">nevent1</code> id
 </Menu.Item>
-<Menu.Item value="copy-text" onclick={() => copyToClipboard(note.content)} class={itemClass}>
+<Menu.Item
+  value="copy-text"
+  onclick={() => copyToClipboardWithToast(note.content, 'text')}
+  class={itemClass}
+>
   Copy text
 </Menu.Item>
 <Menu.Item value="njump-author">

--- a/src/lib/helpers/copyToClipboardWithToast.test.ts
+++ b/src/lib/helpers/copyToClipboardWithToast.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { copyToClipboard } = vi.hoisted(() => ({ copyToClipboard: vi.fn() }));
+const { toaster } = vi.hoisted(() => ({ toaster: { create: vi.fn() } }));
+
+vi.mock('$lib/helpers/copyToClipboard', () => ({ copyToClipboard }));
+vi.mock('$lib/stores/toaster', () => ({ toaster }));
+
+const { copyToClipboardWithToast } = await import('./copyToClipboardWithToast');
+
+describe('copyToClipboardWithToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('copies the text and shows a success toast', async () => {
+    copyToClipboard.mockResolvedValue(undefined);
+
+    await copyToClipboardWithToast('hello', 'npub1');
+
+    expect(copyToClipboard).toHaveBeenCalledWith('hello');
+    expect(toaster.create).toHaveBeenCalledExactlyOnceWith({
+      title: 'Copied npub1',
+      type: 'success',
+    });
+  });
+
+  it('shows an error toast when copying fails', async () => {
+    copyToClipboard.mockRejectedValue(new Error('denied'));
+
+    await copyToClipboardWithToast('hello', 'npub1');
+
+    expect(toaster.create).toHaveBeenCalledExactlyOnceWith({
+      title: 'Failed to copy npub1',
+      type: 'error',
+    });
+  });
+});

--- a/src/lib/helpers/copyToClipboardWithToast.ts
+++ b/src/lib/helpers/copyToClipboardWithToast.ts
@@ -1,0 +1,11 @@
+import { copyToClipboard } from '$lib/helpers/copyToClipboard';
+import { toaster } from '$lib/stores/toaster';
+
+export const copyToClipboardWithToast = async (text: string, label: string): Promise<void> => {
+  try {
+    await copyToClipboard(text);
+    toaster.create({ title: `Copied ${label}`, type: 'success' });
+  } catch {
+    toaster.create({ title: `Failed to copy ${label}`, type: 'error' });
+  }
+};

--- a/src/lib/stores/toaster.ts
+++ b/src/lib/stores/toaster.ts
@@ -1,0 +1,3 @@
+import { createToaster } from '@skeletonlabs/skeleton-svelte';
+
+export const toaster = createToaster({ placement: 'top-end' });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,16 +1,29 @@
 <script lang="ts">
   import '../app.css';
 
+  import { Toast } from '@skeletonlabs/skeleton-svelte';
   import { navigating } from '$app/state';
   import Footer from '$lib/components/Footer.svelte';
   import Header from '$lib/components/Header.svelte';
   import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+  import { toaster } from '$lib/stores/toaster';
 
   interface Props {
     children?: import('svelte').Snippet;
   }
 
   let { children }: Props = $props();
+
+  const toastClass = (type: string | undefined) => {
+    switch (type) {
+      case 'success':
+        return 'preset-tonal-success';
+      case 'error':
+        return 'preset-tonal-error';
+      default:
+        return 'preset-tonal-surface';
+    }
+  };
 </script>
 
 <div class="min-h-svh flex flex-col">
@@ -37,3 +50,11 @@
     <Footer />
   </footer>
 </div>
+
+<Toast.Group {toaster}>
+  {#snippet children(toast)}
+    <Toast {toast} class="card p-4 shadow-xl {toastClass(toast.type)}">
+      <Toast.Title class="font-bold">{toast.title}</Toast.Title>
+    </Toast>
+  {/snippet}
+</Toast.Group>


### PR DESCRIPTION
## Summary
- Add toast notifications (via skeleton-svelte's `Toast` component) so users get visible confirmation when copying npub/note/nevent/text succeeds or fails
- Wrap `copyToClipboard` in a new `copyToClipboardWithToast` helper with try/catch error handling, backed by a shared `toaster` store
- Render a single global `Toast.Group` in `+layout.svelte`, styled per toast type (success/error/default)

## Test plan
- [x] `npx vitest run` — all tests pass, including new `copyToClipboardWithToast.test.ts` covering success and failure paths
- [x] `npx svelte-check` — no errors
- [x] `npx biome check --error-on-warnings` — no errors