### PR TITLE
fix: skip rx-nostr's NIP-11 fetch in autocomplete action

### DIFF
--- a/src/lib/actions/autocomplete.svelte.ts
+++ b/src/lib/actions/autocomplete.svelte.ts
@@ -49,7 +49,10 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
   }
 
   const prefix = opts.prefix ?? '';
-  const rxNostr = createRxNostr({ verifier });
+  // Skips the NIP-11 info document fetch rx-nostr otherwise makes per relay:
+  // it's only used to cap concurrent subscriptions per relay, and this action
+  // never has more than one active search subscription at a time.
+  const rxNostr = createRxNostr({ verifier, skipFetchNip11: true });
   rxNostr.setDefaultRelays(opts.relays);
 
   let triggerStart: number | null = null;


### PR DESCRIPTION
## Summary
- Investigated a flaky CI failure in `src/lib/actions/autocomplete.test.ts` (run https://github.com/akiomik/nosey/actions/runs/29293291312/job/86961352198): the first test timed out at 15000ms, and three later tests in the same file cascaded into failure.
- Root cause: `rx-nostr`'s `createRxNostr()` fetches each relay's NIP-11 info document over real, unmocked HTTP before subscribing (`skipFetchNip11` defaults to `false`). In the test environment this hit the real internet, and its latency (up to ~10s locally against `relay.nostr.band`) leaked into test timing. On a slower/less predictable connection (e.g. a CI runner), this occasionally exceeded the 15s test timeout, and the resulting unhandled failure skipped the test's cleanup (`action?.destroy()`), leaking a live rx-nostr/WebSocket connection into later tests that reuse the same relay URLs.
- NIP-11's `limitation.max_subscriptions` is only used by rx-nostr to cap the number of *concurrent* subscriptions per relay. The `autocomplete` action only ever holds one active search subscription per relay (`cancelPendingSearch` tears down the previous one before starting a new search), so this cap is never relevant here.
- Fix: pass `skipFetchNip11: true` to `createRxNostr()` in `autocomplete.svelte.ts`. Confirmed via a temporary fetch spy that this fully eliminates the network call (no test-side mocking needed).

## Test plan
- [x] `npm run lint`
- [x] `npm run check`
- [x] `npx vitest run src/lib/actions/autocomplete.test.ts` x3 — all 5 tests pass consistently in ~370-420ms (previously the first test alone took ~10.6s)
- [x] `npm run test` (full suite) x3 — all 38 tests pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)