### PR TITLE
fix: dedupe autocomplete search results by pubkey across relays

### DIFF
--- a/src/lib/actions/autocomplete.svelte.ts
+++ b/src/lib/actions/autocomplete.svelte.ts
@@ -1,6 +1,6 @@
 import { verifier } from '@rx-nostr/crypto';
-import { nip19 } from 'nostr-tools';
-import { createRxNostr, createRxOneshotReq, filterBy, latestEach, verify } from 'rx-nostr';
+import { type NostrEvent, nip19 } from 'nostr-tools';
+import { createRxNostr, createRxOneshotReq, filterBy, verify } from 'rx-nostr';
 import type { Subscription } from 'rxjs';
 import { map, toArray } from 'rxjs';
 import { mount, unmount } from 'svelte';
@@ -140,6 +140,29 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     searchToken += 1;
   };
 
+  // rx-nostr's `latestEach` emits the running "latest so far" value on every
+  // update rather than only the final one, so piping it into `toArray()`
+  // would collect every intermediate version too. When relays hold
+  // different-versioned kind:0 events for the same author, that leaves
+  // duplicate pubkeys in the array (and crashes MentionMenu's keyed
+  // `{#each}`). Pick the newest event per pubkey ourselves instead, using the
+  // same tie-break as NIP-01 replaceable events (highest created_at, then
+  // highest id).
+  const pickLatestByPubkey = (events: NostrEvent[]): NostrEvent[] => {
+    const latestByPubkey = new Map<string, NostrEvent>();
+    for (const event of events) {
+      const current = latestByPubkey.get(event.pubkey);
+      if (
+        !current ||
+        current.created_at < event.created_at ||
+        (current.created_at === event.created_at && current.id < event.id)
+      ) {
+        latestByPubkey.set(event.pubkey, event);
+      }
+    }
+    return [...latestByPubkey.values()];
+  };
+
   const parseMentionItem = (pubkey: string, content: string): MentionItem => {
     try {
       const { name, display_name: displayName, picture, nip05 } = JSON.parse(content);
@@ -173,7 +196,6 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
         .pipe(
           filterBy({ kinds: [0], search: query }),
           verify(verifier),
-          latestEach(({ event }) => event.pubkey),
           map(({ event }) => event),
           toArray()
         )
@@ -184,7 +206,7 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
             return;
           }
 
-          menuProps.items = events
+          menuProps.items = pickLatestByPubkey(events)
             .map(({ pubkey, content }) => parseMentionItem(pubkey, content))
             .slice(0, MENU_ITEM_LIMIT);
           menuProps.loading = false;

--- a/src/lib/actions/autocomplete.test.ts
+++ b/src/lib/actions/autocomplete.test.ts
@@ -178,6 +178,53 @@ describe('autocomplete', () => {
     action?.destroy();
   }, 15000);
 
+  it('shows only the newest event when relays return different versions of the same profile', async () => {
+    const [relayA, relayB] = RELAY_URLS.map((url) => new WS(url)) as [WS, WS];
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    const action = autocomplete(input, { relays: RELAY_URLS, prefix: 'from:' });
+
+    input.value = 'from:@bob';
+    input.setSelectionRange(input.value.length, input.value.length);
+    await fireEvent.input(input);
+
+    const sk = generateSecretKey();
+    const now = Math.floor(Date.now() / 1000);
+    const oldEvent = finalizeEvent(
+      { kind: 0, created_at: now - 100, tags: [], content: JSON.stringify({ name: 'bob-old' }) },
+      sk
+    );
+    const newEvent = finalizeEvent(
+      { kind: 0, created_at: now, tags: [], content: JSON.stringify({ name: 'bob-new' }) },
+      sk
+    );
+
+    // One relay only has the stale copy of the profile, the other has the
+    // freshly updated one -- both are valid results for the same pubkey.
+    for (const [relay, event] of [
+      [relayA, oldEvent],
+      [relayB, newEvent],
+    ] as const) {
+      await relay.connected;
+      const raw = await relay.nextMessage;
+      const [, subId] = JSON.parse(raw as string);
+      relay.send(JSON.stringify(['EVENT', subId, event]));
+      relay.send(JSON.stringify(['EOSE', subId]));
+    }
+
+    await vi.waitFor(() => {
+      expect(getMenuContent()).not.toHaveAttribute('hidden');
+      expect(getMenuContent()?.querySelector('button')).not.toBeNull();
+    });
+
+    const buttons = getMenuContent()?.querySelectorAll('button');
+    expect(buttons).toHaveLength(1);
+    expect(buttons?.[0]?.textContent).toContain('bob-new');
+
+    action?.destroy();
+  }, 15000);
+
   it('debounces input so only the final query reaches the relay', async () => {
     const [relayUrl] = RELAY_URLS;
     const relay = new WS(relayUrl);


### PR DESCRIPTION
## Summary
- Multiple relays can hold different-versioned kind:0 profile events for the same author (e.g. a relay with a stale cached copy vs. one with the latest update). `rx-nostr`'s `latestEach` emits the running "latest so far" value on every update rather than only the final one, so piping it into `toArray()` collected every intermediate version, not just the winner.
- This left duplicate pubkeys in the mention search results and crashed `MentionMenu`'s keyed `{#each items as item (item.pubkey)}` block with a Svelte `each_key_duplicate` error.
- Replaced `latestEach` with a manual `pickLatestByPubkey` pass over the collected events that keeps only the newest event per pubkey (same NIP-01 replaceable-event tie-break: highest `created_at`, then highest `id`).

## Test plan
- [x] Added a regression test simulating two relays returning different-versioned profiles for the same pubkey; confirmed it fails against the pre-fix code (`each_key_duplicate` + assertion failure) and passes after the fix.
- [x] `npx vitest run src/lib/actions/autocomplete.test.ts src/lib/components/MentionMenu.test.ts` — 14 passed
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)