### PR TITLE
fix: keep the newest profile event across relays in profileStore

### DIFF
--- a/src/lib/stores/profileStore.test.ts
+++ b/src/lib/stores/profileStore.test.ts
@@ -45,4 +45,49 @@ describe('profileStore', () => {
 
     unsubscribe();
   }, 15000);
+
+  it('ends up with the newest event when relays disagree on the profile version', async () => {
+    const [relayA, relayB, relayC] = [
+      new WS('wss://relay.damus.io'),
+      new WS('wss://nos.lol'),
+      new WS('wss://yabu.me'),
+    ];
+
+    const sk = generateSecretKey();
+    const pubkey = getPublicKey(sk);
+    const now = Math.floor(Date.now() / 1000);
+
+    const oldEvent = finalizeEvent(
+      { kind: 0, created_at: now - 100, tags: [], content: JSON.stringify({ name: 'old' }) },
+      sk
+    );
+    const newEvent = finalizeEvent(
+      { kind: 0, created_at: now, tags: [], content: JSON.stringify({ name: 'new' }) },
+      sk
+    );
+
+    const store = profileStore([pubkey]);
+    const unsubscribe = store.subscribe(() => {});
+
+    // The first relay to answer holds the stale copy; the other two hold the
+    // freshly updated one. Whichever relay wins the race must not matter.
+    const relayEvents: [WS, typeof oldEvent][] = [
+      [relayA, oldEvent],
+      [relayB, newEvent],
+      [relayC, newEvent],
+    ];
+    for (const [relay, event] of relayEvents) {
+      await relay.connected;
+      const raw = await relay.nextMessage;
+      const [, subId] = JSON.parse(raw as string);
+      relay.send(JSON.stringify(['EVENT', subId, event]));
+      relay.send(JSON.stringify(['EOSE', subId]));
+    }
+
+    await vi.waitFor(() => {
+      expect(get(store)[pubkey]?.content).toBe(newEvent.content);
+    });
+
+    unsubscribe();
+  }, 15000);
 });

--- a/src/lib/stores/profileStore.ts
+++ b/src/lib/stores/profileStore.ts
@@ -26,13 +26,15 @@ export const profileStore = (pubkeys: string[]): Readable<Record<string, Nostr.E
     );
 
     sub.subscribe((event) => {
-      update(($profileMap: Record<string, Nostr.Event>) => {
-        if ($profileMap[event.pubkey]) {
-          return { ...$profileMap };
-        }
-
-        return { ...$profileMap, ...Object.fromEntries([[event.pubkey, event]]) };
-      });
+      // `latestEach` only re-emits a pubkey once a strictly newer event for it
+      // has arrived (ties and older events are filtered upstream), so every
+      // emission here is safe to write straight through -- skipping it when
+      // the pubkey is already present would freeze the store on whichever
+      // relay answered first, even if a slower relay held a newer profile.
+      update(($profileMap: Record<string, Nostr.Event>) => ({
+        ...$profileMap,
+        [event.pubkey]: event,
+      }));
     });
 
     return () => rxNostr.dispose();


### PR DESCRIPTION
## Summary
- Follow-up to #326, which fixed a related `latestEach` misuse in the autocomplete action.
- `profileStore` subscribes incrementally (no `toArray()`), updating the store per emission with a guard: `if ($profileMap[event.pubkey]) return unchanged`. This assumed `latestEach` emits at most once per pubkey.
- In reality `latestEach` re-emits a pubkey every time a *strictly newer* event for it arrives (ties/older events are filtered upstream by its internal `compareEvents` comparison). So the guard had it backwards: whichever relay answered first for a pubkey "locked in" that profile, and any genuinely newer profile from a slower relay was silently dropped.
- Fix: drop the guard and always write the incoming event through. Since `latestEach` already guarantees each emission per pubkey is newer than the previous one, this is always safe and doesn't need a manual `toArray()` + dedupe pass like the autocomplete fix did (this store already updates incrementally by design, per a prior "Improve profileStore performance" commit).

## Test plan
- [x] Added a regression test: first-answering relay returns a stale profile, the other two return the fresh one; confirmed it fails against the pre-fix code (store keeps the stale profile) and passes after the fix.
- [x] `npx vitest run src/lib/stores/profileStore.test.ts` — 2 passed
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)