### PR TITLE
perf: search profiles via api.nostr.wine instead of relay NIP-50 search

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Focus on supporting features similar to Twitter search directives.
 ## Features
 
 - `from:npub...` directive
-- `from:@...` for npub completion (using NIP-50)
+- `from:@...` for npub completion
 - `since:YYYY-MM-DD` and `until:YYYY-MM-DD` directives (limited support)
 
 ## Developing

--- a/src/lib/actions/autocomplete.svelte.ts
+++ b/src/lib/actions/autocomplete.svelte.ts
@@ -1,11 +1,9 @@
-import { verifier } from '@rx-nostr/crypto';
-import { type NostrEvent, nip19 } from 'nostr-tools';
-import { createRxNostr, createRxOneshotReq, filterBy, verify } from 'rx-nostr';
-import type { Subscription } from 'rxjs';
-import { map, reduce } from 'rxjs';
+import { nip19 } from 'nostr-tools';
+import type * as Nostr from 'nostr-typedef';
 import { mount, unmount } from 'svelte';
 import { browser } from '$app/environment';
 import MentionMenu from '$lib/components/MentionMenu.svelte';
+import { search as searchProfiles } from '$lib/helpers/search';
 import type { MentionItem } from '$lib/types';
 
 // This intentionally hand-rolls keyboard navigation instead of using
@@ -20,7 +18,6 @@ import type { MentionItem } from '$lib/types';
 //   composed and only the `prefix@query` substring after the trigger should
 //   ever be replaced -- the rest of the buffer must survive untouched.
 export type Opts = {
-  relays: string[];
   prefix: string;
 };
 
@@ -44,22 +41,17 @@ const findTrigger = (textBeforeCaret: string, prefix: string) => {
 };
 
 export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
-  if (!browser || !opts.relays) {
+  if (!browser) {
     return;
   }
 
   const prefix = opts.prefix ?? '';
-  // Skips the NIP-11 info document fetch rx-nostr otherwise makes per relay:
-  // it's only used to cap concurrent subscriptions per relay, and this action
-  // never has more than one active search subscription at a time.
-  const rxNostr = createRxNostr({ verifier, skipFetchNip11: true });
-  rxNostr.setDefaultRelays(opts.relays);
 
   let triggerStart: number | null = null;
   let searchToken = 0;
   let measureCanvas: HTMLCanvasElement | null = null;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  let activeSubscription: Subscription | null = null;
+  let activeController: AbortController | null = null;
 
   const menuProps = $state<{
     open: boolean;
@@ -124,9 +116,9 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
       clearTimeout(debounceTimer);
       debounceTimer = null;
     }
-    if (activeSubscription) {
-      activeSubscription.unsubscribe();
-      activeSubscription = null;
+    if (activeController) {
+      activeController.abort();
+      activeController = null;
     }
   };
 
@@ -140,32 +132,13 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     searchToken += 1;
   };
 
-  // Picks the newest event per pubkey, using the same tie-break as NIP-01
-  // replaceable events (highest created_at, then highest id). rx-nostr's
-  // `latestEach` doesn't fit here: it emits the running "latest so far"
-  // value on every update rather than only the final one, so relays holding
-  // different-versioned kind:0 events for the same author would leave
-  // duplicate pubkeys in the result (and crash MentionMenu's keyed
-  // `{#each}`).
-  const keepNewestPerPubkey = (latestByPubkey: Map<string, NostrEvent>, event: NostrEvent) => {
-    const current = latestByPubkey.get(event.pubkey);
-    if (
-      !current ||
-      current.created_at < event.created_at ||
-      (current.created_at === event.created_at && current.id < event.id)
-    ) {
-      latestByPubkey.set(event.pubkey, event);
-    }
-    return latestByPubkey;
-  };
-
   const parseMentionItem = (pubkey: string, content: string): MentionItem => {
     try {
       const { name, display_name: displayName, picture, nip05 } = JSON.parse(content);
       return { pubkey, content, name: name ?? displayName ?? pubkey, picture, nip05 };
     } catch {
       // Malformed profile content (e.g. a kind:0 event with invalid JSON) shouldn't
-      // crash the search subscription and leave the menu stuck on "Searching...".
+      // crash the search and leave the menu stuck on "Searching...".
       return { pubkey, content, name: pubkey, picture: '', nip05: '' };
     }
   };
@@ -182,31 +155,42 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
 
     menuProps.loading = true;
 
-    debounceTimer = setTimeout(() => {
+    debounceTimer = setTimeout(async () => {
       debounceTimer = null;
+      const controller = new AbortController();
+      activeController = controller;
 
-      const req = createRxOneshotReq({ filters: [{ kinds: [0], search: query, limit: 10 }] });
+      try {
+        const result = await searchProfiles(
+          { query, kind: 0, limit: MENU_ITEM_LIMIT },
+          controller.signal
+        );
+        activeController = null;
 
-      activeSubscription = rxNostr
-        .use(req)
-        .pipe(
-          filterBy({ kinds: [0], search: query }),
-          verify(verifier),
-          map(({ event }) => event),
-          reduce(keepNewestPerPubkey, new Map<string, NostrEvent>())
-        )
-        .subscribe((latestByPubkey) => {
-          activeSubscription = null;
+        if (token !== searchToken) {
+          return;
+        }
 
-          if (token !== searchToken) {
-            return;
-          }
+        menuProps.items = result.data
+          .map(({ pubkey, content }: Nostr.Event) => parseMentionItem(pubkey, content))
+          .slice(0, MENU_ITEM_LIMIT);
+        menuProps.loading = false;
+      } catch (e) {
+        activeController = null;
 
-          menuProps.items = [...latestByPubkey.values()]
-            .map(({ pubkey, content }) => parseMentionItem(pubkey, content))
-            .slice(0, MENU_ITEM_LIMIT);
-          menuProps.loading = false;
-        });
+        if (token !== searchToken) {
+          return;
+        }
+
+        if (e instanceof DOMException && e.name === 'AbortError') {
+          // Superseded by a newer search; that search owns the UI state now.
+          return;
+        }
+
+        // Network/HTTP failure shouldn't leave the menu stuck on "Searching...".
+        menuProps.items = [];
+        menuProps.loading = false;
+      }
     }, SEARCH_DEBOUNCE_MS);
   };
 
@@ -302,7 +286,6 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
       node.removeEventListener('blur', handleBlur);
       cancelPendingSearch();
       unmount(menu);
-      rxNostr.dispose();
     },
   };
 };

--- a/src/lib/actions/autocomplete.test.ts
+++ b/src/lib/actions/autocomplete.test.ts
@@ -1,4 +1,6 @@
 import { fireEvent } from '@testing-library/svelte';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
 import {
   type EventTemplate,
   finalizeEvent,
@@ -6,13 +8,22 @@ import {
   getPublicKey,
   nip19,
 } from 'nostr-tools';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import WS from 'vitest-websocket-mock';
+import type * as Nostr from 'nostr-typedef';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { autocomplete } from './autocomplete.svelte';
 
-const RELAY_URLS: [string, string] = ['wss://search.nos.today', 'wss://relay.nostr.band'];
+const SEARCH_URL = 'https://api.nostr.wine/search';
 
-const respondWithRawContent = async (relays: WS[], content: string) => {
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  document.body.innerHTML = '';
+});
+afterAll(() => server.close());
+
+const makeProfileEvent = (content: string, overrides: Partial<EventTemplate> = {}) => {
   const sk = generateSecretKey();
   const pubkey = getPublicKey(sk);
   const template: EventTemplate = {
@@ -20,75 +31,51 @@ const respondWithRawContent = async (relays: WS[], content: string) => {
     created_at: Math.floor(Date.now() / 1000),
     tags: [],
     content,
+    ...overrides,
   };
-  const event = finalizeEvent(template, sk);
-
-  for (const relay of relays) {
-    await relay.connected;
-    const raw = await relay.nextMessage;
-    const [, subId] = JSON.parse(raw as string);
-    relay.send(JSON.stringify(['EVENT', subId, event]));
-    relay.send(JSON.stringify(['EOSE', subId]));
-  }
-
-  return { pubkey, event };
+  return { pubkey, event: finalizeEvent(template, sk) };
 };
 
-const respondWithProfile = (relays: WS[], content: Record<string, unknown>) =>
-  respondWithRawContent(relays, JSON.stringify(content));
+const mockSearchResult = (events: Nostr.Event[]) => {
+  server.use(
+    http.get(SEARCH_URL, () =>
+      HttpResponse.json({
+        data: events,
+        pagination: {
+          last_page: true,
+          limit: 20,
+          next_url: '',
+          page: 0,
+          total_pages: 1,
+          total_records: events.length,
+        },
+      })
+    )
+  );
+};
 
-// Sends `count` distinct-pubkey kind:0 events to a single relay in response to
-// the one REQ it's expected to receive, then closes the subscription.
-const respondWithProfiles = async (relay: WS, count: number) => {
-  await relay.connected;
-  const raw = await relay.nextMessage;
-  const [, subId] = JSON.parse(raw as string);
-
-  const pubkeys: string[] = [];
-  for (let i = 0; i < count; i++) {
-    const sk = generateSecretKey();
-    const pubkey = getPublicKey(sk);
-    pubkeys.push(pubkey);
-    const template: EventTemplate = {
-      kind: 0,
-      created_at: Math.floor(Date.now() / 1000),
-      tags: [],
-      content: JSON.stringify({ name: `user-${i}` }),
-    };
-    const event = finalizeEvent(template, sk);
-    relay.send(JSON.stringify(['EVENT', subId, event]));
-  }
-  relay.send(JSON.stringify(['EOSE', subId]));
-
-  return pubkeys;
+const mockSearchError = (status: number) => {
+  server.use(http.get(SEARCH_URL, () => HttpResponse.json({ error: 'oops' }, { status })));
 };
 
 const getMenuContent = () =>
   document.body.querySelector('[data-scope="popover"][data-part="content"]');
 
-afterEach(() => {
-  document.body.innerHTML = '';
-  WS.clean();
-});
-
 describe('autocomplete', () => {
   it('opens a menu with search results, renders them safely, and Enter replaces only the trigger text', async () => {
-    const relays = RELAY_URLS.map((url) => new WS(url));
+    const { pubkey, event } = makeProfileEvent(
+      JSON.stringify({ name: '<img src=x onerror=alert(1)>', picture: '', nip05: '' })
+    );
+    mockSearchResult([event]);
 
     const input = document.createElement('input');
     document.body.appendChild(input);
-    const action = autocomplete(input, { relays: RELAY_URLS, prefix: 'from:' });
+    const action = autocomplete(input, { prefix: 'from:' });
 
     input.value = 'hello from:@bob world';
     const caret = 'hello from:@bob'.length;
     input.setSelectionRange(caret, caret);
     await fireEvent.input(input);
-
-    const { pubkey } = await respondWithProfile(relays, {
-      name: '<img src=x onerror=alert(1)>',
-      picture: '',
-      nip05: '',
-    });
 
     await vi.waitFor(() => {
       expect(getMenuContent()).not.toHaveAttribute('hidden');
@@ -106,16 +93,12 @@ describe('autocomplete', () => {
     expect(getMenuContent()).toHaveAttribute('hidden');
 
     action?.destroy();
-  }, 15000);
+  });
 
   it('closes the menu on Escape without changing the input value', async () => {
-    for (const url of RELAY_URLS) {
-      new WS(url);
-    }
-
     const input = document.createElement('input');
     document.body.appendChild(input);
-    const action = autocomplete(input, { relays: RELAY_URLS, prefix: 'from:' });
+    const action = autocomplete(input, { prefix: 'from:' });
 
     input.value = 'from:@bob';
     input.setSelectionRange(input.value.length, input.value.length);
@@ -134,17 +117,16 @@ describe('autocomplete', () => {
   });
 
   it('recovers from a profile event with invalid JSON content instead of getting stuck loading', async () => {
-    const relays = RELAY_URLS.map((url) => new WS(url));
+    const { pubkey, event } = makeProfileEvent('{not valid json');
+    mockSearchResult([event]);
 
     const input = document.createElement('input');
     document.body.appendChild(input);
-    const action = autocomplete(input, { relays: RELAY_URLS, prefix: 'from:' });
+    const action = autocomplete(input, { prefix: 'from:' });
 
     input.value = 'from:@bob';
     input.setSelectionRange(input.value.length, input.value.length);
     await fireEvent.input(input);
-
-    const { pubkey } = await respondWithRawContent(relays, '{not valid json');
 
     await vi.waitFor(() => {
       expect(getMenuContent()).not.toHaveAttribute('hidden');
@@ -156,108 +138,114 @@ describe('autocomplete', () => {
     expect(getMenuContent()?.textContent).toContain(pubkey);
 
     action?.destroy();
-  }, 15000);
+  });
 
-  it('caps merged results from multiple relays at 10 items', async () => {
-    const relays = RELAY_URLS.map((url) => new WS(url));
+  it('recovers from a search API failure instead of getting stuck loading', async () => {
+    mockSearchError(502);
 
     const input = document.createElement('input');
     document.body.appendChild(input);
-    const action = autocomplete(input, { relays: RELAY_URLS, prefix: 'from:' });
+    const action = autocomplete(input, { prefix: 'from:' });
 
     input.value = 'from:@bob';
     input.setSelectionRange(input.value.length, input.value.length);
     await fireEvent.input(input);
 
-    await Promise.all(relays.map((relay) => respondWithProfiles(relay, 6)));
+    await vi.waitFor(() => {
+      expect(getMenuContent()).not.toHaveAttribute('hidden');
+      expect(getMenuContent()?.textContent).toContain('No matches found');
+    });
+
+    action?.destroy();
+  });
+
+  it('caps results at 10 items when the API returns more than the limit', async () => {
+    const events = Array.from(
+      { length: 12 },
+      (_, i) => makeProfileEvent(JSON.stringify({ name: `user-${i}` })).event
+    );
+    mockSearchResult(events);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    const action = autocomplete(input, { prefix: 'from:' });
+
+    input.value = 'from:@bob';
+    input.setSelectionRange(input.value.length, input.value.length);
+    await fireEvent.input(input);
 
     await vi.waitFor(() => {
       expect(getMenuContent()?.querySelectorAll('button').length).toBe(10);
     });
 
     action?.destroy();
-  }, 15000);
+  });
 
-  it('shows only the newest event when relays return different versions of the same profile', async () => {
-    const [relayA, relayB] = RELAY_URLS.map((url) => new WS(url)) as [WS, WS];
+  it('navigates results with arrow keys and Enter confirms the highlighted item', async () => {
+    const first = makeProfileEvent(JSON.stringify({ name: 'first' }));
+    const second = makeProfileEvent(JSON.stringify({ name: 'second' }));
+    mockSearchResult([first.event, second.event]);
 
     const input = document.createElement('input');
     document.body.appendChild(input);
-    const action = autocomplete(input, { relays: RELAY_URLS, prefix: 'from:' });
+    const action = autocomplete(input, { prefix: 'from:' });
 
-    input.value = 'from:@bob';
+    input.value = 'from:@bo';
     input.setSelectionRange(input.value.length, input.value.length);
     await fireEvent.input(input);
 
-    const sk = generateSecretKey();
-    const now = Math.floor(Date.now() / 1000);
-    const oldEvent = finalizeEvent(
-      { kind: 0, created_at: now - 100, tags: [], content: JSON.stringify({ name: 'bob-old' }) },
-      sk
-    );
-    const newEvent = finalizeEvent(
-      { kind: 0, created_at: now, tags: [], content: JSON.stringify({ name: 'bob-new' }) },
-      sk
-    );
-
-    // One relay only has the stale copy of the profile, the other has the
-    // freshly updated one -- both are valid results for the same pubkey.
-    for (const [relay, event] of [
-      [relayA, oldEvent],
-      [relayB, newEvent],
-    ] as const) {
-      await relay.connected;
-      const raw = await relay.nextMessage;
-      const [, subId] = JSON.parse(raw as string);
-      relay.send(JSON.stringify(['EVENT', subId, event]));
-      relay.send(JSON.stringify(['EOSE', subId]));
-    }
-
     await vi.waitFor(() => {
-      expect(getMenuContent()).not.toHaveAttribute('hidden');
-      expect(getMenuContent()?.querySelector('button')).not.toBeNull();
+      expect(getMenuContent()?.querySelectorAll('button').length).toBe(2);
     });
 
-    const buttons = getMenuContent()?.querySelectorAll('button');
-    expect(buttons).toHaveLength(1);
-    expect(buttons?.[0]?.textContent).toContain('bob-new');
+    await fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(input.value).toBe(`from:${nip19.npubEncode(second.pubkey)}`);
 
     action?.destroy();
-  }, 15000);
+  });
 
-  it('debounces input so only the final query reaches the relay', async () => {
-    const [relayUrl] = RELAY_URLS;
-    const relay = new WS(relayUrl);
+  it('debounces input so only the final query reaches the API', async () => {
+    const requestedQueries: string[] = [];
+    server.use(
+      http.get(SEARCH_URL, ({ request }) => {
+        const url = new URL(request.url);
+        requestedQueries.push(url.searchParams.get('query') ?? '');
+        return HttpResponse.json({
+          data: [],
+          pagination: {
+            last_page: true,
+            limit: 20,
+            next_url: '',
+            page: 0,
+            total_pages: 1,
+            total_records: 0,
+          },
+        });
+      })
+    );
 
     const input = document.createElement('input');
     document.body.appendChild(input);
-    const action = autocomplete(input, { relays: [relayUrl], prefix: 'from:' });
+    const action = autocomplete(input, { prefix: 'from:' });
 
     input.value = 'from:@b';
     input.setSelectionRange(input.value.length, input.value.length);
     await fireEvent.input(input);
 
     // Type the rest before the debounce timer fires; the first keystroke's
-    // search must never reach the relay.
+    // search must never reach the API.
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     input.value = 'from:@bob';
     input.setSelectionRange(input.value.length, input.value.length);
     await fireEvent.input(input);
 
-    await relay.connected;
-    const raw = await relay.nextMessage;
-    const [type, subId, filter] = JSON.parse(raw as string);
-    expect(type).toBe('REQ');
-    expect(filter.search).toBe('bob');
-
-    relay.send(JSON.stringify(['EOSE', subId]));
-
     await vi.waitFor(() => {
-      const reqMessages = relay.messages.filter((m) => JSON.parse(m as string)[0] === 'REQ');
-      expect(reqMessages).toHaveLength(1);
+      expect(requestedQueries).toEqual(['bob']);
     });
 
     action?.destroy();
-  }, 15000);
+  });
 });

--- a/src/lib/components/AdvancedSearchModal.svelte
+++ b/src/lib/components/AdvancedSearchModal.svelte
@@ -44,10 +44,7 @@
           type="text"
           bind:value={formData.from}
           placeholder="npub1..."
-          use:autocomplete={{
-            relays: ['wss://search.nos.today', 'wss://relay.nostr.band'],
-            prefix: '',
-          }}
+          use:autocomplete={{ prefix: '' }}
         />
       </div>
     </label>

--- a/src/lib/helpers/search.ts
+++ b/src/lib/helpers/search.ts
@@ -24,13 +24,16 @@ function encode(query: Partial<SearchQuery>): Encoded<Partial<SearchQuery>> {
   return Object.fromEntries(entries);
 }
 
-export async function search(query: Partial<SearchQuery>): Promise<SearchResult> {
+export async function search(
+  query: Partial<SearchQuery>,
+  signal?: AbortSignal
+): Promise<SearchResult> {
   // TODO: Don't search when query is empty
   const params = new URLSearchParams(encode(query));
   const url = `https://api.nostr.wine/search?${params}`;
   console.debug(url, query);
 
-  const res = await fetch(url);
+  const res = await fetch(url, { signal });
   const data = await res.json();
 
   if (!res.ok) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -96,10 +96,7 @@
         value={q}
         aria-label="search"
         oninput={handleQuery}
-        use:autocomplete={{
-          relays: ['wss://search.nos.today', 'wss://relay.nostr.band'],
-          prefix: 'from:',
-        }}
+        use:autocomplete={{ prefix: 'from:' }}
         autofocus
       />
       <button type="submit" class="ig-btn preset-filled-primary-500">


### PR DESCRIPTION
## Summary

- `from:@` npub補完がrelay NIP-50検索(`wss://search.nos.today`, `wss://relay.nostr.band`)で数秒〜30秒かかっていた問題を計測で切り分け、`relay.nostr.band`がユーザー環境からも接続不能であること、`search.nos.today`のEOSE待機がクエリ依存で最大30秒程度までばらつくことを確認
- 既にnote検索(kind:1)で使っている`api.nostr.wine/search`をkind:0(プロフィール)向けに使うよう変更。実測でどのクエリも~200-600ms程度に安定
- 署名検証は行わない方針とし、既存のnote検索と信頼モデルを揃えた
- キャッシュ層(tanstack query/SWR等)は今回は導入せず、素朴なfetch + `AbortController`によるキャンセルのみ

## Test plan

- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm run test` (12 files / 41 tests, all passing)
- [x] `autocomplete.test.ts` を `vitest-websocket-mock` から `msw` ベースに全面書き換え、API障害時にloadingが解除されるケースと矢印キーナビゲーションのケースを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)