### PR TITLE
refactor: rebuild autocomplete search on rxjs, add 429 backoff

### DIFF
--- a/src/lib/actions/autocomplete.svelte.ts
+++ b/src/lib/actions/autocomplete.svelte.ts
@@ -1,10 +1,24 @@
 import { nip19 } from 'nostr-tools';
 import type * as Nostr from 'nostr-typedef';
+import {
+  catchError,
+  debounceTime,
+  EMPTY,
+  map,
+  merge,
+  Observable,
+  retry,
+  Subject,
+  switchMap,
+  throwError,
+  timer,
+} from 'rxjs';
 import { mount, unmount } from 'svelte';
 import { browser } from '$app/environment';
 import MentionMenu from '$lib/components/MentionMenu.svelte';
+import { HttpTooManyRequestsError } from '$lib/errors';
 import { search as searchProfiles } from '$lib/helpers/search';
-import type { MentionItem } from '$lib/types';
+import type { MentionItem, SearchResult } from '$lib/types';
 
 // This intentionally hand-rolls keyboard navigation instead of using
 // @skeletonlabs/skeleton-svelte's `Menu` or `Combobox` (both wrap @zag-js
@@ -24,6 +38,18 @@ export type Opts = {
 const TRIGGER_SUFFIX = '@';
 const MENU_ITEM_LIMIT = 10;
 const SEARCH_DEBOUNCE_MS = 250;
+const RATE_LIMIT_MAX_RETRIES = 3;
+const RATE_LIMIT_BASE_DELAY_MS = 300;
+
+// Backs off only on 429s; any other error is rethrown immediately so `retry`
+// stops and lets `catchError` surface it as a failed search right away.
+const retryOnRateLimit = (error: unknown, retryCount: number): Observable<number> => {
+  if (error instanceof HttpTooManyRequestsError && retryCount <= RATE_LIMIT_MAX_RETRIES) {
+    return timer(RATE_LIMIT_BASE_DELAY_MS * 2 ** (retryCount - 1));
+  }
+
+  return throwError(() => error);
+};
 
 const findTrigger = (textBeforeCaret: string, prefix: string) => {
   const trigger = `${prefix}${TRIGGER_SUFFIX}`;
@@ -48,10 +74,7 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
   const prefix = opts.prefix ?? '';
 
   let triggerStart: number | null = null;
-  let searchToken = 0;
   let measureCanvas: HTMLCanvasElement | null = null;
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  let activeController: AbortController | null = null;
 
   const menuProps = $state<{
     open: boolean;
@@ -111,25 +134,13 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     return { x, y, width: 0, height: 0 };
   };
 
-  const cancelPendingSearch = () => {
-    if (debounceTimer !== null) {
-      clearTimeout(debounceTimer);
-      debounceTimer = null;
-    }
-    if (activeController) {
-      activeController.abort();
-      activeController = null;
-    }
-  };
-
   const closeMenu = () => {
-    cancelPendingSearch();
+    cancel$.next();
     menuProps.open = false;
     menuProps.items = [];
     menuProps.activeIndex = 0;
     menuProps.loading = false;
     triggerStart = null;
-    searchToken += 1;
   };
 
   const parseMentionItem = (pubkey: string, content: string): MentionItem => {
@@ -143,55 +154,72 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     }
   };
 
-  const search = (query: string) => {
-    cancelPendingSearch();
-    const token = ++searchToken;
+  const fetchProfiles = (query: string): Observable<SearchResult> =>
+    new Observable<SearchResult>((subscriber) => {
+      const controller = new AbortController();
 
+      searchProfiles({ query, kind: 0, limit: MENU_ITEM_LIMIT }, controller.signal)
+        .then((result) => {
+          subscriber.next(result);
+          subscriber.complete();
+        })
+        .catch((error) => subscriber.error(error));
+
+      // Ties fetch cancellation to unsubscription, so `switchMap` aborts the
+      // previous request in flight as soon as a newer query supersedes it.
+      return () => controller.abort();
+    });
+
+  // `query$` drives both the synchronous "Searching..." feedback (below,
+  // undebounced) and the debounced network fetch below it. `cancel$` bypasses
+  // the debounce to abort an in-flight or pending fetch immediately when the
+  // menu closes, instead of waiting out `SEARCH_DEBOUNCE_MS`.
+  const query$ = new Subject<string>();
+  const cancel$ = new Subject<void>();
+
+  const uiSub = query$.subscribe((query) => {
     if (query === '') {
       menuProps.items = [];
       menuProps.loading = false;
-      return;
+    } else {
+      menuProps.loading = true;
     }
+  });
 
-    menuProps.loading = true;
+  const searchSub = merge(
+    query$.pipe(debounceTime(SEARCH_DEBOUNCE_MS)),
+    cancel$.pipe(map(() => ''))
+  )
+    .pipe(
+      // Switching to a new inner observable unsubscribes the previous one,
+      // which aborts its fetch and discards its (now stale) response --
+      // replacing the hand-rolled AbortController/search-token bookkeeping.
+      switchMap((query) => {
+        if (query === '') {
+          return EMPTY;
+        }
 
-    debounceTimer = setTimeout(async () => {
-      debounceTimer = null;
-      const controller = new AbortController();
-      activeController = controller;
-
-      try {
-        const result = await searchProfiles(
-          { query, kind: 0, limit: MENU_ITEM_LIMIT },
-          controller.signal
+        return fetchProfiles(query).pipe(
+          retry({ delay: retryOnRateLimit }),
+          catchError(() => {
+            // Network/HTTP failure (or retries exhausted) shouldn't leave the
+            // menu stuck on "Searching...".
+            menuProps.items = [];
+            menuProps.loading = false;
+            return EMPTY;
+          })
         );
-        activeController = null;
+      })
+    )
+    .subscribe((result) => {
+      menuProps.items = result.data
+        .map(({ pubkey, content }: Nostr.Event) => parseMentionItem(pubkey, content))
+        .slice(0, MENU_ITEM_LIMIT);
+      menuProps.loading = false;
+    });
 
-        if (token !== searchToken) {
-          return;
-        }
-
-        menuProps.items = result.data
-          .map(({ pubkey, content }: Nostr.Event) => parseMentionItem(pubkey, content))
-          .slice(0, MENU_ITEM_LIMIT);
-        menuProps.loading = false;
-      } catch (e) {
-        activeController = null;
-
-        if (token !== searchToken) {
-          return;
-        }
-
-        if (e instanceof DOMException && e.name === 'AbortError') {
-          // Superseded by a newer search; that search owns the UI state now.
-          return;
-        }
-
-        // Network/HTTP failure shouldn't leave the menu stuck on "Searching...".
-        menuProps.items = [];
-        menuProps.loading = false;
-      }
-    }, SEARCH_DEBOUNCE_MS);
+  const search = (query: string) => {
+    query$.next(query);
   };
 
   const selectItem = (item: MentionItem) => {
@@ -284,7 +312,8 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
       node.removeEventListener('input', handleInput);
       node.removeEventListener('keydown', handleKeydown);
       node.removeEventListener('blur', handleBlur);
-      cancelPendingSearch();
+      uiSub.unsubscribe();
+      searchSub.unsubscribe();
       unmount(menu);
     },
   };

--- a/src/lib/actions/autocomplete.test.ts
+++ b/src/lib/actions/autocomplete.test.ts
@@ -206,6 +206,70 @@ describe('autocomplete', () => {
     action?.destroy();
   });
 
+  it('retries on 429 with backoff and eventually shows results', async () => {
+    const { event } = makeProfileEvent(JSON.stringify({ name: 'bob' }));
+    let attempts = 0;
+    server.use(
+      http.get(SEARCH_URL, () => {
+        attempts += 1;
+        if (attempts <= 2) {
+          return HttpResponse.json({ error: 'rate limited' }, { status: 429 });
+        }
+        return HttpResponse.json({
+          data: [event],
+          pagination: {
+            last_page: true,
+            limit: 20,
+            next_url: '',
+            page: 0,
+            total_pages: 1,
+            total_records: 1,
+          },
+        });
+      })
+    );
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    const action = autocomplete(input, { prefix: 'from:' });
+
+    input.value = 'from:@bob';
+    input.setSelectionRange(input.value.length, input.value.length);
+    await fireEvent.input(input);
+
+    await vi.waitFor(
+      () => {
+        expect(getMenuContent()?.textContent).toContain('bob');
+      },
+      { timeout: 5000 }
+    );
+
+    expect(attempts).toBe(3);
+
+    action?.destroy();
+  });
+
+  it('gives up after exhausting 429 retries instead of retrying forever', async () => {
+    mockSearchError(429);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    const action = autocomplete(input, { prefix: 'from:' });
+
+    input.value = 'from:@bob';
+    input.setSelectionRange(input.value.length, input.value.length);
+    await fireEvent.input(input);
+
+    await vi.waitFor(
+      () => {
+        expect(getMenuContent()?.textContent).toContain('No matches found');
+      },
+      { timeout: 5000 }
+    );
+
+    action?.destroy();
+  });
+
   it('debounces input so only the final query reaches the API', async () => {
     const requestedQueries: string[] = [];
     server.use(

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,5 @@
 export class HttpBadGatewayError extends Error {}
 
 export class HttpBadRequestError extends Error {}
+
+export class HttpTooManyRequestsError extends Error {}

--- a/src/lib/helpers/search.test.ts
+++ b/src/lib/helpers/search.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { HttpBadGatewayError, HttpBadRequestError } from '$lib/errors';
+import { HttpBadGatewayError, HttpBadRequestError, HttpTooManyRequestsError } from '$lib/errors';
 import type { SearchResult } from '$lib/types';
 import { search } from './search';
 
@@ -37,6 +37,16 @@ describe('search', () => {
     );
 
     await expect(search({ query: 'hello' })).rejects.toThrow(HttpBadRequestError);
+  });
+
+  it('throws HttpTooManyRequestsError on a 429 response', async () => {
+    server.use(
+      http.get('https://api.nostr.wine/search', () =>
+        HttpResponse.json({ error: 'rate limited' }, { status: 429 })
+      )
+    );
+
+    await expect(search({ query: 'hello' })).rejects.toThrow(HttpTooManyRequestsError);
   });
 
   it('throws HttpBadGatewayError on a 5xx response', async () => {

--- a/src/lib/helpers/search.ts
+++ b/src/lib/helpers/search.ts
@@ -1,4 +1,4 @@
-import { HttpBadGatewayError, HttpBadRequestError } from '$lib/errors';
+import { HttpBadGatewayError, HttpBadRequestError, HttpTooManyRequestsError } from '$lib/errors';
 import type { Encoded, SearchQuery, SearchResult } from '$lib/types';
 
 function encode(query: Partial<SearchQuery>): Encoded<Partial<SearchQuery>> {
@@ -37,7 +37,9 @@ export async function search(
   const data = await res.json();
 
   if (!res.ok) {
-    if (res.status < 500) {
+    if (res.status === 429) {
+      throw new HttpTooManyRequestsError(JSON.stringify(data.error));
+    } else if (res.status < 500) {
       throw new HttpBadRequestError(JSON.stringify(data.error));
     } else {
       throw new HttpBadGatewayError(JSON.stringify(data.error));

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,6 +1,6 @@
 import type { RequestEvent } from '@sveltejs/kit';
 import { error } from '@sveltejs/kit';
-import { HttpBadGatewayError, HttpBadRequestError } from '$lib/errors';
+import { HttpBadGatewayError, HttpBadRequestError, HttpTooManyRequestsError } from '$lib/errors';
 import { parseQuery } from '$lib/helpers/parseQuery';
 import { search } from '$lib/helpers/search';
 
@@ -28,6 +28,10 @@ export async function load({ url }: RequestEvent) {
     return { q, page, result };
   } catch (e) {
     // TODO: Improve error message
+
+    if (e instanceof HttpTooManyRequestsError) {
+      throw error(429, JSON.parse(e.message));
+    }
 
     if (e instanceof HttpBadRequestError) {
       throw error(400, JSON.parse(e.message));


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled debounce timer / `AbortController` / search-token race guard in the mention-autocomplete action with an rxjs `Subject` piped through `debounceTime` + `switchMap`, so cancellation and stale-response handling ride on rxjs's own subscription/teardown semantics instead of bespoke bookkeeping (rxjs is already a direct dependency via `profileStore.ts`).
- Adds a distinct `HttpTooManyRequestsError` for 429 responses from `api.nostr.wine` (previously indistinguishable from any other 4xx), with exponential-backoff retries (300ms/600ms/1200ms, up to 3 attempts) applied only to autocomplete's rate-limited searches.
- Threads the new error type through `+page.server.ts`'s post search so a 429 there now surfaces as `error(429, ...)` instead of falling through to an unhandled 500.

## Test plan
- [x] `npm run test` — 44 tests pass, including new cases for 429-then-recover, 429-exhausted, and existing debounce/race/keyboard-nav coverage
- [x] `npm run lint`
- [x] `npm run check`