### PR TITLE
refactor: extract rate-limited profile suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "linkify-plugin-mention": "^4.3.3",
         "linkifyjs": "^4.3.3",
         "nostr-tools": "^2.23.9",
+        "rxjs": "^7.8.2",
         "rx-nostr": "^3.7.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "linkify-plugin-mention": "^4.3.3",
     "linkifyjs": "^4.3.3",
     "nostr-tools": "^2.23.9",
+    "rxjs": "^7.8.2",
     "rx-nostr": "^3.7.5"
   }
 }

--- a/src/lib/actions/autocomplete.svelte.ts
+++ b/src/lib/actions/autocomplete.svelte.ts
@@ -1,24 +1,9 @@
 import { nip19 } from 'nostr-tools';
-import type * as Nostr from 'nostr-typedef';
-import {
-  catchError,
-  debounceTime,
-  EMPTY,
-  map,
-  merge,
-  Observable,
-  retry,
-  Subject,
-  switchMap,
-  throwError,
-  timer,
-} from 'rxjs';
 import { mount, unmount } from 'svelte';
 import { browser } from '$app/environment';
 import MentionMenu from '$lib/components/MentionMenu.svelte';
-import { HttpTooManyRequestsError } from '$lib/errors';
-import { search as searchProfiles } from '$lib/helpers/search';
-import type { MentionItem, SearchResult } from '$lib/types';
+import { profileSuggestions } from '$lib/stores/profileSuggestions';
+import type { MentionItem } from '$lib/types';
 
 // This intentionally hand-rolls keyboard navigation instead of using
 // @skeletonlabs/skeleton-svelte's `Menu` or `Combobox` (both wrap @zag-js
@@ -36,20 +21,6 @@ export type Opts = {
 };
 
 const TRIGGER_SUFFIX = '@';
-const MENU_ITEM_LIMIT = 10;
-const SEARCH_DEBOUNCE_MS = 250;
-const RATE_LIMIT_MAX_RETRIES = 3;
-const RATE_LIMIT_BASE_DELAY_MS = 300;
-
-// Backs off only on 429s; any other error is rethrown immediately so `retry`
-// stops and lets `catchError` surface it as a failed search right away.
-const retryOnRateLimit = (error: unknown, retryCount: number): Observable<number> => {
-  if (error instanceof HttpTooManyRequestsError && retryCount <= RATE_LIMIT_MAX_RETRIES) {
-    return timer(RATE_LIMIT_BASE_DELAY_MS * 2 ** (retryCount - 1));
-  }
-
-  return throwError(() => error);
-};
 
 const findTrigger = (textBeforeCaret: string, prefix: string) => {
   const trigger = `${prefix}${TRIGGER_SUFFIX}`;
@@ -75,6 +46,7 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
 
   let triggerStart: number | null = null;
   let measureCanvas: HTMLCanvasElement | null = null;
+  const suggestions = profileSuggestions();
 
   const menuProps = $state<{
     open: boolean;
@@ -82,6 +54,7 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     getAnchorRect: () => { x: number; y: number; width: number; height: number };
     loading: boolean;
     items: MentionItem[];
+    error: 'timeout' | 'unavailable' | null;
     activeIndex: number;
     onOpenChange: (open: boolean) => void;
     onSelect: (item: MentionItem) => void;
@@ -91,6 +64,7 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     getAnchorRect: () => computeAnchorRect(),
     loading: false,
     items: [],
+    error: null,
     activeIndex: 0,
     onOpenChange: (open) => {
       if (!open) {
@@ -135,92 +109,20 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
   };
 
   const closeMenu = () => {
-    cancel$.next();
+    suggestions.cancel();
     menuProps.open = false;
     menuProps.items = [];
     menuProps.activeIndex = 0;
     menuProps.loading = false;
+    menuProps.error = null;
     triggerStart = null;
   };
 
-  const parseMentionItem = (pubkey: string, content: string): MentionItem => {
-    try {
-      const { name, display_name: displayName, picture, nip05 } = JSON.parse(content);
-      return { pubkey, content, name: name ?? displayName ?? pubkey, picture, nip05 };
-    } catch {
-      // Malformed profile content (e.g. a kind:0 event with invalid JSON) shouldn't
-      // crash the search and leave the menu stuck on "Searching...".
-      return { pubkey, content, name: pubkey, picture: '', nip05: '' };
-    }
-  };
-
-  const fetchProfiles = (query: string): Observable<SearchResult> =>
-    new Observable<SearchResult>((subscriber) => {
-      const controller = new AbortController();
-
-      searchProfiles({ query, kind: 0, limit: MENU_ITEM_LIMIT }, controller.signal)
-        .then((result) => {
-          subscriber.next(result);
-          subscriber.complete();
-        })
-        .catch((error) => subscriber.error(error));
-
-      // Ties fetch cancellation to unsubscription, so `switchMap` aborts the
-      // previous request in flight as soon as a newer query supersedes it.
-      return () => controller.abort();
-    });
-
-  // `query$` drives both the synchronous "Searching..." feedback (below,
-  // undebounced) and the debounced network fetch below it. `cancel$` bypasses
-  // the debounce to abort an in-flight or pending fetch immediately when the
-  // menu closes, instead of waiting out `SEARCH_DEBOUNCE_MS`.
-  const query$ = new Subject<string>();
-  const cancel$ = new Subject<void>();
-
-  const uiSub = query$.subscribe((query) => {
-    if (query === '') {
-      menuProps.items = [];
-      menuProps.loading = false;
-    } else {
-      menuProps.loading = true;
-    }
+  const unsubscribeSuggestions = suggestions.subscribe(({ loading, items, error }) => {
+    menuProps.loading = loading;
+    menuProps.items = items;
+    menuProps.error = error;
   });
-
-  const searchSub = merge(
-    query$.pipe(debounceTime(SEARCH_DEBOUNCE_MS)),
-    cancel$.pipe(map(() => ''))
-  )
-    .pipe(
-      // Switching to a new inner observable unsubscribes the previous one,
-      // which aborts its fetch and discards its (now stale) response --
-      // replacing the hand-rolled AbortController/search-token bookkeeping.
-      switchMap((query) => {
-        if (query === '') {
-          return EMPTY;
-        }
-
-        return fetchProfiles(query).pipe(
-          retry({ delay: retryOnRateLimit }),
-          catchError(() => {
-            // Network/HTTP failure (or retries exhausted) shouldn't leave the
-            // menu stuck on "Searching...".
-            menuProps.items = [];
-            menuProps.loading = false;
-            return EMPTY;
-          })
-        );
-      })
-    )
-    .subscribe((result) => {
-      menuProps.items = result.data
-        .map(({ pubkey, content }: Nostr.Event) => parseMentionItem(pubkey, content))
-        .slice(0, MENU_ITEM_LIMIT);
-      menuProps.loading = false;
-    });
-
-  const search = (query: string) => {
-    query$.next(query);
-  };
 
   const selectItem = (item: MentionItem) => {
     if (triggerStart === null) {
@@ -254,7 +156,7 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
     menuProps.open = true;
     menuProps.activeIndex = 0;
 
-    search(match.query);
+    suggestions.search(match.query);
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
@@ -312,8 +214,8 @@ export const autocomplete = (node: HTMLInputElement, opts: Partial<Opts>) => {
       node.removeEventListener('input', handleInput);
       node.removeEventListener('keydown', handleKeydown);
       node.removeEventListener('blur', handleBlur);
-      uiSub.unsubscribe();
-      searchSub.unsubscribe();
+      unsubscribeSuggestions();
+      suggestions.destroy();
       unmount(menu);
     },
   };

--- a/src/lib/actions/autocomplete.test.ts
+++ b/src/lib/actions/autocomplete.test.ts
@@ -1,191 +1,77 @@
 import { fireEvent } from '@testing-library/svelte';
-import { HttpResponse, http } from 'msw';
-import { setupServer } from 'msw/node';
-import {
-  type EventTemplate,
-  finalizeEvent,
-  generateSecretKey,
-  getPublicKey,
-  nip19,
-} from 'nostr-tools';
-import type * as Nostr from 'nostr-typedef';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import { writable } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProfileSuggestions, ProfileSuggestionsState } from '$lib/stores/profileSuggestions';
+import type { MentionItem } from '$lib/types';
+
+const { profileSuggestionsMock } = vi.hoisted(() => ({ profileSuggestionsMock: vi.fn() }));
+
+vi.mock('$lib/stores/profileSuggestions', () => ({
+  profileSuggestions: profileSuggestionsMock,
+}));
+
 import { autocomplete } from './autocomplete.svelte';
 
-const SEARCH_URL = 'https://api.nostr.wine/search';
-
-const server = setupServer();
-
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-afterEach(() => {
-  server.resetHandlers();
-  document.body.innerHTML = '';
+const makeItem = (pubkey: string, name: string): MentionItem => ({
+  pubkey,
+  content: JSON.stringify({ name }),
+  name,
+  picture: '',
+  nip05: '',
 });
-afterAll(() => server.close());
 
-const makeProfileEvent = (content: string, overrides: Partial<EventTemplate> = {}) => {
-  const sk = generateSecretKey();
-  const pubkey = getPublicKey(sk);
-  const template: EventTemplate = {
-    kind: 0,
-    created_at: Math.floor(Date.now() / 1000),
-    tags: [],
-    content,
-    ...overrides,
+const createSuggestions = () => {
+  const state = writable<ProfileSuggestionsState>({ loading: false, items: [], error: null });
+  const suggestions: ProfileSuggestions = {
+    subscribe: state.subscribe,
+    search: vi.fn(),
+    cancel: vi.fn(() => state.set({ loading: false, items: [], error: null })),
+    destroy: vi.fn(),
   };
-  return { pubkey, event: finalizeEvent(template, sk) };
+
+  return { state, suggestions };
 };
 
-const mockSearchResult = (events: Nostr.Event[]) => {
-  server.use(
-    http.get(SEARCH_URL, () =>
-      HttpResponse.json({
-        data: events,
-        pagination: {
-          last_page: true,
-          limit: 20,
-          next_url: '',
-          page: 0,
-          total_pages: 1,
-          total_records: events.length,
-        },
-      })
-    )
-  );
-};
+let state: ReturnType<typeof writable<ProfileSuggestionsState>>;
+let suggestions: ProfileSuggestions;
 
-const mockSearchError = (status: number) => {
-  server.use(http.get(SEARCH_URL, () => HttpResponse.json({ error: 'oops' }, { status })));
-};
+beforeEach(() => {
+  ({ state, suggestions } = createSuggestions());
+  profileSuggestionsMock.mockReturnValue(suggestions);
+});
 
-const getMenuContent = () =>
-  document.body.querySelector('[data-scope="popover"][data-part="content"]');
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
 
 describe('autocomplete', () => {
-  it('opens a menu with search results, renders them safely, and Enter replaces only the trigger text', async () => {
-    const { pubkey, event } = makeProfileEvent(
-      JSON.stringify({ name: '<img src=x onerror=alert(1)>', picture: '', nip05: '' })
-    );
-    mockSearchResult([event]);
-
+  it('passes the trigger query to the suggestions store and Enter replaces only the trigger text', async () => {
+    const item = makeItem('a'.repeat(64), 'Alice');
     const input = document.createElement('input');
     document.body.appendChild(input);
     const action = autocomplete(input, { prefix: 'from:' });
 
-    input.value = 'hello from:@bob world';
-    const caret = 'hello from:@bob'.length;
+    input.value = 'hello from:@alice world';
+    const caret = 'hello from:@alice'.length;
     input.setSelectionRange(caret, caret);
     await fireEvent.input(input);
 
-    await vi.waitFor(() => {
-      expect(getMenuContent()).not.toHaveAttribute('hidden');
-      expect(getMenuContent()?.querySelector('button')).not.toBeNull();
-    });
+    expect(suggestions.search).toHaveBeenCalledWith('alice');
 
-    // The malicious name must show up as inert text, never as a parsed element/attribute.
-    const content = getMenuContent();
-    expect(content?.querySelector('img[onerror]')).toBeNull();
-    expect(content?.textContent).toContain('<img src=x onerror=alert(1)>');
-
+    state.set({ loading: false, items: [item], error: null });
     await fireEvent.keyDown(input, { key: 'Enter' });
 
-    expect(input.value).toBe(`hello from:${nip19.npubEncode(pubkey)} world`);
-    expect(getMenuContent()).toHaveAttribute('hidden');
+    expect(input.value).toBe(`hello from:${nip19.npubEncode(item.pubkey)} world`);
+    expect(suggestions.cancel).toHaveBeenCalled();
 
     action?.destroy();
   });
 
-  it('closes the menu on Escape without changing the input value', async () => {
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    const action = autocomplete(input, { prefix: 'from:' });
-
-    input.value = 'from:@bob';
-    input.setSelectionRange(input.value.length, input.value.length);
-    await fireEvent.input(input);
-
-    await vi.waitFor(() => {
-      expect(getMenuContent()).not.toHaveAttribute('hidden');
-    });
-
-    await fireEvent.keyDown(input, { key: 'Escape' });
-
-    expect(getMenuContent()).toHaveAttribute('hidden');
-    expect(input.value).toBe('from:@bob');
-
-    action?.destroy();
-  });
-
-  it('recovers from a profile event with invalid JSON content instead of getting stuck loading', async () => {
-    const { pubkey, event } = makeProfileEvent('{not valid json');
-    mockSearchResult([event]);
-
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    const action = autocomplete(input, { prefix: 'from:' });
-
-    input.value = 'from:@bob';
-    input.setSelectionRange(input.value.length, input.value.length);
-    await fireEvent.input(input);
-
-    await vi.waitFor(() => {
-      expect(getMenuContent()).not.toHaveAttribute('hidden');
-      expect(getMenuContent()?.textContent).not.toContain('Searching...');
-    });
-
-    // Falls back to the raw pubkey as the display name instead of throwing and
-    // leaving the menu stuck on "Searching...".
-    expect(getMenuContent()?.textContent).toContain(pubkey);
-
-    action?.destroy();
-  });
-
-  it('recovers from a search API failure instead of getting stuck loading', async () => {
-    mockSearchError(502);
-
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    const action = autocomplete(input, { prefix: 'from:' });
-
-    input.value = 'from:@bob';
-    input.setSelectionRange(input.value.length, input.value.length);
-    await fireEvent.input(input);
-
-    await vi.waitFor(() => {
-      expect(getMenuContent()).not.toHaveAttribute('hidden');
-      expect(getMenuContent()?.textContent).toContain('No matches found');
-    });
-
-    action?.destroy();
-  });
-
-  it('caps results at 10 items when the API returns more than the limit', async () => {
-    const events = Array.from(
-      { length: 12 },
-      (_, i) => makeProfileEvent(JSON.stringify({ name: `user-${i}` })).event
-    );
-    mockSearchResult(events);
-
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    const action = autocomplete(input, { prefix: 'from:' });
-
-    input.value = 'from:@bob';
-    input.setSelectionRange(input.value.length, input.value.length);
-    await fireEvent.input(input);
-
-    await vi.waitFor(() => {
-      expect(getMenuContent()?.querySelectorAll('button').length).toBe(10);
-    });
-
-    action?.destroy();
-  });
-
-  it('navigates results with arrow keys and Enter confirms the highlighted item', async () => {
-    const first = makeProfileEvent(JSON.stringify({ name: 'first' }));
-    const second = makeProfileEvent(JSON.stringify({ name: 'second' }));
-    mockSearchResult([first.event, second.event]);
-
+  it('uses the highlighted suggestion for ArrowDown then Enter', async () => {
+    const first = makeItem('a'.repeat(64), 'Alice');
+    const second = makeItem('b'.repeat(64), 'Bob');
     const input = document.createElement('input');
     document.body.appendChild(input);
     const action = autocomplete(input, { prefix: 'from:' });
@@ -193,42 +79,18 @@ describe('autocomplete', () => {
     input.value = 'from:@bo';
     input.setSelectionRange(input.value.length, input.value.length);
     await fireEvent.input(input);
-
-    await vi.waitFor(() => {
-      expect(getMenuContent()?.querySelectorAll('button').length).toBe(2);
-    });
+    state.set({ loading: false, items: [first, second], error: null });
 
     await fireEvent.keyDown(input, { key: 'ArrowDown' });
     await fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(input.value).toBe(`from:${nip19.npubEncode(second.pubkey)}`);
+    expect(suggestions.cancel).toHaveBeenCalled();
 
     action?.destroy();
   });
 
-  it('retries on 429 with backoff and eventually shows results', async () => {
-    const { event } = makeProfileEvent(JSON.stringify({ name: 'bob' }));
-    let attempts = 0;
-    server.use(
-      http.get(SEARCH_URL, () => {
-        attempts += 1;
-        if (attempts <= 2) {
-          return HttpResponse.json({ error: 'rate limited' }, { status: 429 });
-        }
-        return HttpResponse.json({
-          data: [event],
-          pagination: {
-            last_page: true,
-            limit: 20,
-            next_url: '',
-            page: 0,
-            total_pages: 1,
-            total_records: 1,
-          },
-        });
-      })
-    );
-
+  it('cancels suggestions when Escape closes the menu', async () => {
     const input = document.createElement('input');
     document.body.appendChild(input);
     const action = autocomplete(input, { prefix: 'from:' });
@@ -236,80 +98,12 @@ describe('autocomplete', () => {
     input.value = 'from:@bob';
     input.setSelectionRange(input.value.length, input.value.length);
     await fireEvent.input(input);
+    await fireEvent.keyDown(input, { key: 'Escape' });
 
-    await vi.waitFor(
-      () => {
-        expect(getMenuContent()?.textContent).toContain('bob');
-      },
-      { timeout: 5000 }
-    );
-
-    expect(attempts).toBe(3);
+    expect(suggestions.cancel).toHaveBeenCalledTimes(1);
+    expect(input.value).toBe('from:@bob');
 
     action?.destroy();
-  });
-
-  it('gives up after exhausting 429 retries instead of retrying forever', async () => {
-    mockSearchError(429);
-
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    const action = autocomplete(input, { prefix: 'from:' });
-
-    input.value = 'from:@bob';
-    input.setSelectionRange(input.value.length, input.value.length);
-    await fireEvent.input(input);
-
-    await vi.waitFor(
-      () => {
-        expect(getMenuContent()?.textContent).toContain('No matches found');
-      },
-      { timeout: 5000 }
-    );
-
-    action?.destroy();
-  });
-
-  it('debounces input so only the final query reaches the API', async () => {
-    const requestedQueries: string[] = [];
-    server.use(
-      http.get(SEARCH_URL, ({ request }) => {
-        const url = new URL(request.url);
-        requestedQueries.push(url.searchParams.get('query') ?? '');
-        return HttpResponse.json({
-          data: [],
-          pagination: {
-            last_page: true,
-            limit: 20,
-            next_url: '',
-            page: 0,
-            total_pages: 1,
-            total_records: 0,
-          },
-        });
-      })
-    );
-
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    const action = autocomplete(input, { prefix: 'from:' });
-
-    input.value = 'from:@b';
-    input.setSelectionRange(input.value.length, input.value.length);
-    await fireEvent.input(input);
-
-    // Type the rest before the debounce timer fires; the first keystroke's
-    // search must never reach the API.
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    input.value = 'from:@bob';
-    input.setSelectionRange(input.value.length, input.value.length);
-    await fireEvent.input(input);
-
-    await vi.waitFor(() => {
-      expect(requestedQueries).toEqual(['bob']);
-    });
-
-    action?.destroy();
+    expect(suggestions.destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/components/MentionMenu.svelte
+++ b/src/lib/components/MentionMenu.svelte
@@ -12,6 +12,7 @@
     anchorElement: HTMLElement;
     loading: boolean;
     items: MentionItem[];
+    error?: 'timeout' | 'unavailable' | null;
     activeIndex: number;
     onSelect: (item: MentionItem) => void;
   }
@@ -23,6 +24,7 @@
     anchorElement,
     loading,
     items,
+    error = null,
     activeIndex,
     onSelect,
   }: Props = $props();
@@ -64,6 +66,10 @@
     <div {...popover().getContentProps()} class="card preset-tonal-surface p-4 z-[300] mt-2 shadow">
       {#if loading}
         <p class="px-3 py-1.5 opacity-60">Searching...</p>
+      {:else if error === 'timeout'}
+        <p class="px-3 py-1.5 opacity-60">Search timed out. Please try again.</p>
+      {:else if error === 'unavailable'}
+        <p class="px-3 py-1.5 opacity-60">Could not load suggestions. Please try again.</p>
       {:else if items.length === 0}
         <p class="px-3 py-1.5 opacity-60">No matches found</p>
       {:else}

--- a/src/lib/components/MentionMenu.test.ts
+++ b/src/lib/components/MentionMenu.test.ts
@@ -48,6 +48,24 @@ describe('MentionMenu', () => {
     expect(getContent()?.querySelector('button')).toBeNull();
   });
 
+  it('distinguishes a timed-out search from no matches', () => {
+    render(MentionMenu, {
+      props: { ...baseProps, loading: false, items: [], error: 'timeout', activeIndex: 0 },
+    });
+
+    expect(getContent()?.textContent).toContain('Search timed out. Please try again.');
+    expect(getContent()?.textContent).not.toContain('No matches found');
+  });
+
+  it('shows an unavailable-service message for non-timeout errors', () => {
+    render(MentionMenu, {
+      props: { ...baseProps, loading: false, items: [], error: 'unavailable', activeIndex: 0 },
+    });
+
+    expect(getContent()?.textContent).toContain('Could not load suggestions. Please try again.');
+    expect(getContent()?.textContent).not.toContain('No matches found');
+  });
+
   it('renders a malicious item name as inert text, never as markup', () => {
     const items = [makeItem({ name: '<img src=x onerror=alert(1)>' })];
     render(MentionMenu, { props: { ...baseProps, loading: false, items, activeIndex: 0 } });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -2,4 +2,11 @@ export class HttpBadGatewayError extends Error {}
 
 export class HttpBadRequestError extends Error {}
 
-export class HttpTooManyRequestsError extends Error {}
+export class HttpTooManyRequestsError extends Error {
+  constructor(
+    message: string,
+    public readonly retryAfterMs?: number
+  ) {
+    super(message);
+  }
+}

--- a/src/lib/helpers/rateLimitedSearch.test.ts
+++ b/src/lib/helpers/rateLimitedSearch.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HttpTooManyRequestsError } from '$lib/errors';
+import type { SearchResult } from '$lib/types';
+import { createRateLimitedSearch } from './rateLimitedSearch';
+
+const result: SearchResult = {
+  data: [],
+  pagination: {
+    last_page: true,
+    limit: 20,
+    next_url: '',
+    page: 0,
+    total_pages: 1,
+    total_records: 0,
+  },
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createRateLimitedSearch', () => {
+  it('spaces shared requests at least the configured interval apart', async () => {
+    vi.useFakeTimers();
+    const search = vi.fn().mockResolvedValue(result);
+    const rateLimitedSearch = createRateLimitedSearch(search, 1_000);
+
+    const first = rateLimitedSearch({ query: 'alice' });
+    const second = rateLimitedSearch({ query: 'bob' });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(search).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(search).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(search).toHaveBeenCalledTimes(2);
+
+    await expect(first).resolves.toEqual(result);
+    await expect(second).resolves.toEqual(result);
+  });
+
+  it('honors a 429 Retry-After delay before releasing the next request', async () => {
+    vi.useFakeTimers();
+    const search = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpTooManyRequestsError('rate limited', 2_000))
+      .mockResolvedValueOnce(result);
+    const rateLimitedSearch = createRateLimitedSearch(search, 1_000);
+
+    const first = rateLimitedSearch({ query: 'alice' });
+    const firstRejected = expect(first).rejects.toThrow(HttpTooManyRequestsError);
+    await vi.advanceTimersByTimeAsync(0);
+    await firstRejected;
+
+    const second = rateLimitedSearch({ query: 'bob' });
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(search).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(search).toHaveBeenCalledTimes(2);
+
+    await expect(second).resolves.toEqual(result);
+  });
+});

--- a/src/lib/helpers/rateLimitedSearch.ts
+++ b/src/lib/helpers/rateLimitedSearch.ts
@@ -1,0 +1,74 @@
+import { HttpTooManyRequestsError } from '$lib/errors';
+import { search } from '$lib/helpers/search';
+import type { SearchQuery, SearchResult } from '$lib/types';
+
+const MINIMUM_REQUEST_INTERVAL_MS = 1_000;
+
+type Search = (query: Partial<SearchQuery>, signal?: AbortSignal) => Promise<SearchResult>;
+
+const abortError = () => new DOMException('The operation was aborted', 'AbortError');
+
+const wait = (durationMs: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError());
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, durationMs);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortError());
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+
+export const createRateLimitedSearch = (
+  request: Search = search,
+  minimumIntervalMs = MINIMUM_REQUEST_INTERVAL_MS
+): Search => {
+  let nextRequestAt = 0;
+  let reservationQueue = Promise.resolve();
+
+  const reserveRequestSlot = (signal?: AbortSignal) => {
+    const reservation = reservationQueue.then(async () => {
+      while (true) {
+        if (signal?.aborted) {
+          throw abortError();
+        }
+
+        const delayMs = nextRequestAt - Date.now();
+        if (delayMs <= 0) {
+          nextRequestAt = Date.now() + minimumIntervalMs;
+          return;
+        }
+
+        await wait(delayMs, signal);
+      }
+    });
+
+    reservationQueue = reservation.catch(() => undefined);
+    return reservation;
+  };
+
+  return async (query, signal) => {
+    await reserveRequestSlot(signal);
+
+    try {
+      return await request(query, signal);
+    } catch (error) {
+      if (error instanceof HttpTooManyRequestsError) {
+        const retryDelayMs = Math.max(error.retryAfterMs ?? minimumIntervalMs, minimumIntervalMs);
+        nextRequestAt = Math.max(nextRequestAt, Date.now() + retryDelayMs);
+      }
+      throw error;
+    }
+  };
+};
+
+// All client-side profile suggestion inputs share this coordinator, so their
+// requests respect api.nostr.wine's one-request-per-second limit together.
+export const rateLimitedSearch = createRateLimitedSearch();

--- a/src/lib/helpers/search.test.ts
+++ b/src/lib/helpers/search.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { HttpBadGatewayError, HttpBadRequestError, HttpTooManyRequestsError } from '$lib/errors';
+import { HttpBadGatewayError, HttpBadRequestError } from '$lib/errors';
 import type { SearchResult } from '$lib/types';
 import { search } from './search';
 
@@ -42,11 +42,16 @@ describe('search', () => {
   it('throws HttpTooManyRequestsError on a 429 response', async () => {
     server.use(
       http.get('https://api.nostr.wine/search', () =>
-        HttpResponse.json({ error: 'rate limited' }, { status: 429 })
+        HttpResponse.json(
+          { error: 'rate limited' },
+          { status: 429, headers: { 'Retry-After': '2' } }
+        )
       )
     );
 
-    await expect(search({ query: 'hello' })).rejects.toThrow(HttpTooManyRequestsError);
+    await expect(search({ query: 'hello' })).rejects.toMatchObject({
+      retryAfterMs: 2_000,
+    });
   });
 
   it('throws HttpBadGatewayError on a 5xx response', async () => {

--- a/src/lib/helpers/search.ts
+++ b/src/lib/helpers/search.ts
@@ -1,6 +1,24 @@
 import { HttpBadGatewayError, HttpBadRequestError, HttpTooManyRequestsError } from '$lib/errors';
 import type { Encoded, SearchQuery, SearchResult } from '$lib/types';
 
+function parseRetryAfter(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, Math.ceil(seconds * 1000));
+  }
+
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return undefined;
+  }
+
+  return Math.max(0, timestamp - Date.now());
+}
+
 function encode(query: Partial<SearchQuery>): Encoded<Partial<SearchQuery>> {
   const entries = Object.entries(query)
     .map(([key, value]) => {
@@ -38,7 +56,10 @@ export async function search(
 
   if (!res.ok) {
     if (res.status === 429) {
-      throw new HttpTooManyRequestsError(JSON.stringify(data.error));
+      throw new HttpTooManyRequestsError(
+        JSON.stringify(data.error),
+        parseRetryAfter(res.headers.get('Retry-After'))
+      );
     } else if (res.status < 500) {
       throw new HttpBadRequestError(JSON.stringify(data.error));
     } else {

--- a/src/lib/stores/profileSuggestions.test.ts
+++ b/src/lib/stores/profileSuggestions.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HttpTooManyRequestsError } from '$lib/errors';
+import type { SearchResult } from '$lib/types';
+import { type ProfileSuggestionsState, profileSuggestions } from './profileSuggestions';
+
+const emptyResult: SearchResult = {
+  data: [],
+  pagination: {
+    last_page: true,
+    limit: 20,
+    next_url: '',
+    page: 0,
+    total_pages: 1,
+    total_records: 0,
+  },
+};
+
+const result = (content: string, pubkey = 'a'.repeat(64)): SearchResult => ({
+  ...emptyResult,
+  data: [
+    {
+      id: 'b'.repeat(64),
+      pubkey,
+      created_at: 0,
+      kind: 0,
+      tags: [],
+      content,
+      sig: 'c'.repeat(128),
+    },
+  ],
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('profileSuggestions', () => {
+  it('debounces queries and exposes parsed suggestion items', async () => {
+    vi.useFakeTimers();
+    const search = vi.fn().mockResolvedValue(result(JSON.stringify({ name: 'Alice' })));
+    const suggestions = profileSuggestions({ search });
+    let latest: ProfileSuggestionsState = { loading: false, items: [], error: null };
+    const unsubscribe = suggestions.subscribe((state) => {
+      latest = state;
+    });
+
+    suggestions.search('a');
+    suggestions.search('alice');
+
+    expect(latest.loading).toBe(true);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(search).toHaveBeenCalledWith('alice', expect.any(AbortSignal));
+    expect(latest).toEqual({
+      loading: false,
+      items: [expect.objectContaining({ name: 'Alice' })],
+      error: null,
+    });
+
+    unsubscribe();
+    suggestions.destroy();
+  });
+
+  it('cancels a pending debounce when the menu closes', async () => {
+    vi.useFakeTimers();
+    const search = vi.fn().mockResolvedValue(emptyResult);
+    const suggestions = profileSuggestions({ search });
+
+    suggestions.search('alice');
+    suggestions.cancel();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(search).not.toHaveBeenCalled();
+    suggestions.destroy();
+  });
+
+  it('aborts an in-flight request when a newer query supersedes it', async () => {
+    vi.useFakeTimers();
+    let firstSignal: AbortSignal | undefined;
+    const search = vi.fn((query: string, signal: AbortSignal) => {
+      if (query === 'alice') {
+        firstSignal = signal;
+        return new Promise<SearchResult>(() => {});
+      }
+      return Promise.resolve(result(JSON.stringify({ name: 'Bob' })));
+    });
+    const suggestions = profileSuggestions({ search });
+
+    suggestions.search('alice');
+    await vi.advanceTimersByTimeAsync(250);
+    suggestions.search('bob');
+
+    expect(firstSignal?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(search).toHaveBeenLastCalledWith('bob', expect.any(AbortSignal));
+
+    suggestions.destroy();
+  });
+
+  it('waits at least one second before retrying a 429 response', async () => {
+    vi.useFakeTimers();
+    const search = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpTooManyRequestsError('rate limited'))
+      .mockResolvedValueOnce(result(JSON.stringify({ name: 'Alice' })));
+    const suggestions = profileSuggestions({ search });
+
+    suggestions.search('alice');
+    await vi.advanceTimersByTimeAsync(250);
+    expect(search).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(search).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(search).toHaveBeenCalledTimes(2);
+
+    suggestions.destroy();
+  });
+
+  it('does not retry errors other than 429', async () => {
+    vi.useFakeTimers();
+    const search = vi.fn().mockRejectedValue(new Error('bad gateway'));
+    const suggestions = profileSuggestions({ search });
+    let latest: ProfileSuggestionsState = { loading: false, items: [], error: null };
+    const unsubscribe = suggestions.subscribe((state) => {
+      latest = state;
+    });
+
+    suggestions.search('alice');
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(latest.error).toBe('unavailable');
+    unsubscribe();
+    suggestions.destroy();
+  });
+
+  it('reports a timeout separately from an unavailable service', async () => {
+    vi.useFakeTimers();
+    const suggestions = profileSuggestions({
+      search: vi.fn(() => new Promise<SearchResult>(() => {})),
+      timeoutMs: 100,
+    });
+    let latest: ProfileSuggestionsState = { loading: false, items: [], error: null };
+    const unsubscribe = suggestions.subscribe((state) => {
+      latest = state;
+    });
+
+    suggestions.search('alice');
+    await vi.advanceTimersByTimeAsync(350);
+
+    expect(latest).toEqual({ loading: false, items: [], error: 'timeout' });
+    unsubscribe();
+    suggestions.destroy();
+  });
+
+  it('falls back to the pubkey for malformed profile JSON', async () => {
+    vi.useFakeTimers();
+    const pubkey = 'd'.repeat(64);
+    const suggestions = profileSuggestions({
+      search: vi.fn().mockResolvedValue(result('{not valid json', pubkey)),
+    });
+    let latestName = '';
+    const unsubscribe = suggestions.subscribe((state) => {
+      latestName = state.items[0]?.name ?? '';
+    });
+
+    suggestions.search('alice');
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(latestName).toBe(pubkey);
+    unsubscribe();
+    suggestions.destroy();
+  });
+});

--- a/src/lib/stores/profileSuggestions.ts
+++ b/src/lib/stores/profileSuggestions.ts
@@ -1,0 +1,142 @@
+import type * as Nostr from 'nostr-typedef';
+import {
+  catchError,
+  distinctUntilChanged,
+  EMPTY,
+  map,
+  Observable,
+  retry,
+  Subject,
+  switchMap,
+  TimeoutError,
+  timeout,
+  timer,
+} from 'rxjs';
+import { type Readable, writable } from 'svelte/store';
+import { HttpTooManyRequestsError } from '$lib/errors';
+import { rateLimitedSearch } from '$lib/helpers/rateLimitedSearch';
+import type { MentionItem, SearchResult } from '$lib/types';
+
+const MENU_ITEM_LIMIT = 10;
+const SEARCH_DEBOUNCE_MS = 250;
+const RATE_LIMIT_MAX_RETRIES = 3;
+const RATE_LIMIT_RETRY_DELAY_MS = 1_000;
+const SEARCH_TIMEOUT_MS = 5_000;
+
+export type ProfileSuggestionsState = {
+  loading: boolean;
+  items: MentionItem[];
+  error: 'timeout' | 'unavailable' | null;
+};
+
+export type ProfileSuggestions = Readable<ProfileSuggestionsState> & {
+  search: (query: string) => void;
+  cancel: () => void;
+  destroy: () => void;
+};
+
+type ProfileSearch = (query: string, signal: AbortSignal) => Promise<SearchResult>;
+
+type Options = Partial<{
+  search: ProfileSearch;
+  debounceMs: number;
+  maxRetries: number;
+  timeoutMs: number;
+}>;
+
+const initialState: ProfileSuggestionsState = { loading: false, items: [], error: null };
+
+const retryOnRateLimit = (error: unknown): Observable<number> => {
+  if (error instanceof HttpTooManyRequestsError) {
+    return timer(
+      Math.max(error.retryAfterMs ?? RATE_LIMIT_RETRY_DELAY_MS, RATE_LIMIT_RETRY_DELAY_MS)
+    );
+  }
+
+  throw error;
+};
+
+const parseMentionItem = (pubkey: string, content: string): MentionItem => {
+  try {
+    const { name, display_name: displayName, picture, nip05 } = JSON.parse(content);
+    return { pubkey, content, name: name ?? displayName ?? pubkey, picture, nip05 };
+  } catch {
+    return { pubkey, content, name: pubkey, picture: '', nip05: '' };
+  }
+};
+
+const defaultSearch: ProfileSearch = (query, signal) =>
+  rateLimitedSearch({ query, kind: 0, limit: MENU_ITEM_LIMIT }, signal);
+
+const fetchProfiles = (query: string, search: ProfileSearch): Observable<SearchResult> =>
+  new Observable<SearchResult>((subscriber) => {
+    const controller = new AbortController();
+
+    search(query, controller.signal)
+      .then((result) => {
+        subscriber.next(result);
+        subscriber.complete();
+      })
+      .catch((error) => subscriber.error(error));
+
+    return () => controller.abort();
+  });
+
+export const profileSuggestions = (options: Options = {}): ProfileSuggestions => {
+  const search = options.search ?? defaultSearch;
+  const debounceMs = options.debounceMs ?? SEARCH_DEBOUNCE_MS;
+  const maxRetries = options.maxRetries ?? RATE_LIMIT_MAX_RETRIES;
+  const timeoutMs = options.timeoutMs ?? SEARCH_TIMEOUT_MS;
+  const state = writable<ProfileSuggestionsState>(initialState);
+  const query$ = new Subject<string | null>();
+
+  const subscription = query$
+    .pipe(
+      distinctUntilChanged(),
+      switchMap((query) => {
+        if (query === null) {
+          state.set(initialState);
+          return EMPTY;
+        }
+
+        if (query === '') {
+          state.set(initialState);
+          return EMPTY;
+        }
+
+        state.set({ loading: true, items: [], error: null });
+        return timer(debounceMs).pipe(
+          switchMap(() =>
+            fetchProfiles(query, search).pipe(
+              timeout({ first: timeoutMs }),
+              retry({ count: maxRetries, delay: retryOnRateLimit })
+            )
+          ),
+          map((result) =>
+            result.data
+              .map(({ pubkey, content }: Nostr.Event) => parseMentionItem(pubkey, content))
+              .slice(0, MENU_ITEM_LIMIT)
+          ),
+          catchError((error: unknown) => {
+            state.set({
+              loading: false,
+              items: [],
+              error: error instanceof TimeoutError ? 'timeout' : 'unavailable',
+            });
+            return EMPTY;
+          })
+        );
+      })
+    )
+    .subscribe((items) => state.set({ loading: false, items, error: null }));
+
+  return {
+    subscribe: state.subscribe,
+    search: (query) => query$.next(query),
+    cancel: () => query$.next(null),
+    destroy: () => {
+      query$.complete();
+      subscription.unsubscribe();
+    },
+  };
+};


### PR DESCRIPTION
## Summary

Refactor profile autocomplete so the input action focuses on UI behavior while a dedicated store owns the suggestion-request lifecycle.

- Extract debouncing, cancellation, stale-request replacement, profile parsing, and retry handling into `profileSuggestions`.
- Add a shared client-side request coordinator that spaces profile suggestion requests by at least one second.
- Respect `Retry-After` on 429 responses and retry rate-limited requests only.
- Add a timeout state and distinguish timeout, unavailable service, and no-match states in the suggestion menu.
- Declare `rxjs` as a direct runtime dependency.

## Testing

- `npm test`
- `npm run check`
- `npm run lint`
- `npm run build`
