### PR TITLE
fix(autocomplete): avoid nested portal lifecycle

### DIFF
--- a/src/lib/actions/AutocompleteTestHost.svelte
+++ b/src/lib/actions/AutocompleteTestHost.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { autocomplete } from './autocomplete.svelte';
+
+  interface Props {
+    prefix?: string;
+  }
+
+  let { prefix = '' }: Props = $props();
+</script>
+
+<input aria-label="Autocomplete" use:autocomplete={{ prefix }} />

--- a/src/lib/actions/autocomplete.test.ts
+++ b/src/lib/actions/autocomplete.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 import { nip19 } from 'nostr-tools';
 import { writable } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -11,7 +11,7 @@ vi.mock('$lib/stores/profileSuggestions', () => ({
   profileSuggestions: profileSuggestionsMock,
 }));
 
-import { autocomplete } from './autocomplete.svelte';
+import AutocompleteTestHost from './AutocompleteTestHost.svelte';
 
 const makeItem = (pubkey: string, name: string): MentionItem => ({
   pubkey,
@@ -42,16 +42,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  document.body.innerHTML = '';
   vi.clearAllMocks();
 });
 
 describe('autocomplete', () => {
   it('passes the trigger query to the suggestions store and Enter replaces only the trigger text', async () => {
     const item = makeItem('a'.repeat(64), 'Alice');
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    const action = autocomplete(input, { prefix: 'from:' });
+    const { getByRole } = render(AutocompleteTestHost, { props: { prefix: 'from:' } });
+    const input = getByRole('textbox') as HTMLInputElement;
 
     input.value = 'hello from:@alice world';
     const caret = 'hello from:@alice'.length;
@@ -65,16 +63,13 @@ describe('autocomplete', () => {
 
     expect(input.value).toBe(`hello from:${nip19.npubEncode(item.pubkey)} world`);
     expect(suggestions.cancel).toHaveBeenCalled();
-
-    action?.destroy();
   });
 
   it('uses the highlighted suggestion for ArrowDown then Enter', async () => {
     const first = makeItem('a'.repeat(64), 'Alice');
     const second = makeItem('b'.repeat(64), 'Bob');
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    const action = autocomplete(input, { prefix: 'from:' });
+    const { getByRole } = render(AutocompleteTestHost, { props: { prefix: 'from:' } });
+    const input = getByRole('textbox') as HTMLInputElement;
 
     input.value = 'from:@bo';
     input.setSelectionRange(input.value.length, input.value.length);
@@ -86,14 +81,11 @@ describe('autocomplete', () => {
 
     expect(input.value).toBe(`from:${nip19.npubEncode(second.pubkey)}`);
     expect(suggestions.cancel).toHaveBeenCalled();
-
-    action?.destroy();
   });
 
   it('cancels suggestions when Escape closes the menu', async () => {
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    const action = autocomplete(input, { prefix: 'from:' });
+    const { getByRole, unmount } = render(AutocompleteTestHost, { props: { prefix: 'from:' } });
+    const input = getByRole('textbox') as HTMLInputElement;
 
     input.value = 'from:@bob';
     input.setSelectionRange(input.value.length, input.value.length);
@@ -103,7 +95,17 @@ describe('autocomplete', () => {
     expect(suggestions.cancel).toHaveBeenCalledTimes(1);
     expect(input.value).toBe('from:@bob');
 
-    action?.destroy();
+    unmount();
     expect(suggestions.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not read a derived after the action and menu are unmounted', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { unmount } = render(AutocompleteTestHost, { props: { prefix: 'from:' } });
+
+    unmount();
+    await Promise.resolve();
+
+    expect(warn.mock.calls.flat().join('\n')).not.toContain('derived_inert');
   });
 });

--- a/src/lib/components/MentionMenu.svelte
+++ b/src/lib/components/MentionMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Portal, usePopover } from '@skeletonlabs/skeleton-svelte';
+  import { usePopover } from '@skeletonlabs/skeleton-svelte';
   import type { MentionItem } from '$lib/types';
   import ProfileAvatar from './ProfileAvatar.svelte';
 
@@ -61,37 +61,35 @@
   const itemClass = 'w-full flex justify-start items-center gap-2 text-left rounded-base px-3 py-1.5';
 </script>
 
-<Portal>
-  <div {...popover().getPositionerProps()}>
-    <div {...popover().getContentProps()} class="card preset-tonal-surface p-4 z-[300] mt-2 shadow">
-      {#if loading}
-        <p class="px-3 py-1.5 opacity-60">Searching...</p>
-      {:else if error === 'timeout'}
-        <p class="px-3 py-1.5 opacity-60">Search timed out. Please try again.</p>
-      {:else if error === 'unavailable'}
-        <p class="px-3 py-1.5 opacity-60">Could not load suggestions. Please try again.</p>
-      {:else if items.length === 0}
-        <p class="px-3 py-1.5 opacity-60">No matches found</p>
-      {:else}
-        <ul class="space-y-1">
-          {#each items as item, i (item.pubkey)}
-            <li>
-              <button
-                type="button"
-                class="{itemClass} {i === activeIndex ? 'preset-tonal' : 'hover:preset-tonal'}"
-                onmousedown={(e) => e.preventDefault()}
-                onclick={() => onSelect(item)}
-              >
-                <ProfileAvatar picture={item.picture} name={item.name} class="w-6 h-6 shrink-0" />
-                <span class="truncate">{item.name}</span>
-                {#if item.nip05}
-                  <span class="truncate"><code class="code">{item.nip05}</code></span>
-                {/if}
-              </button>
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </div>
+<div {...popover().getPositionerProps()}>
+  <div {...popover().getContentProps()} class="card preset-tonal-surface p-4 z-[300] mt-2 shadow">
+    {#if loading}
+      <p class="px-3 py-1.5 opacity-60">Searching...</p>
+    {:else if error === 'timeout'}
+      <p class="px-3 py-1.5 opacity-60">Search timed out. Please try again.</p>
+    {:else if error === 'unavailable'}
+      <p class="px-3 py-1.5 opacity-60">Could not load suggestions. Please try again.</p>
+    {:else if items.length === 0}
+      <p class="px-3 py-1.5 opacity-60">No matches found</p>
+    {:else}
+      <ul class="space-y-1">
+        {#each items as item, i (item.pubkey)}
+          <li>
+            <button
+              type="button"
+              class="{itemClass} {i === activeIndex ? 'preset-tonal' : 'hover:preset-tonal'}"
+              onmousedown={(e) => e.preventDefault()}
+              onclick={() => onSelect(item)}
+            >
+              <ProfileAvatar picture={item.picture} name={item.name} class="w-6 h-6 shrink-0" />
+              <span class="truncate">{item.name}</span>
+              {#if item.nip05}
+                <span class="truncate"><code class="code">{item.nip05}</code></span>
+              {/if}
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {/if}
   </div>
-</Portal>
+</div>


### PR DESCRIPTION
## Summary

- remove the redundant Portal around the programmatically mounted mention menu
- run autocomplete tests through a real `use:autocomplete` host component
- add coverage that unmounting autocomplete does not emit Svelte's `derived_inert` warning

## Testing

- npm test
- npm run check
- npm run lint
- npm run build