### PR TITLE
fix(profile): validate metadata content

### DIFF
--- a/src/lib/search/nostr.test.ts
+++ b/src/lib/search/nostr.test.ts
@@ -1,7 +1,13 @@
 import { nip19 } from 'nostr-tools';
 import { finalizeEvent, generateSecretKey } from 'nostr-tools/pure';
 import { describe, expect, it } from 'vitest';
-import { NostrEventSchema, npubCodec } from './nostr';
+import {
+  formatNip05Identifier,
+  Nip05IdentifierSchema,
+  NostrEventSchema,
+  NostrProfileContentSchema,
+  npubCodec,
+} from './nostr';
 
 const mattnNpub = 'npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6';
 
@@ -17,6 +23,47 @@ describe('Nostr schemas', () => {
 
     expect(npubCodec.decode(mattnNpub)).toBe(pubkey);
     expect(npubCodec.encode(pubkey as string)).toBe(mattnNpub);
+  });
+
+  describe('Nip05IdentifierSchema', () => {
+    it('accepts NIP-05 identifiers with the allowed local-part characters', () => {
+      expect(Nip05IdentifierSchema.safeParse('Alice-_.9@example.com').success).toBe(true);
+      expect(Nip05IdentifierSchema.safeParse('alice@EXAMPLE.com').success).toBe(true);
+    });
+
+    it.each([
+      'alice+tag@example.com',
+      'alice@example.com@invalid',
+      'alice@',
+      '@example.com',
+    ])('rejects an invalid NIP-05 identifier: %s', (identifier) => {
+      expect(Nip05IdentifierSchema.safeParse(identifier).success).toBe(false);
+    });
+
+    it('formats a root identifier as its domain for display', () => {
+      expect(formatNip05Identifier('_@bob.com')).toBe('bob.com');
+      expect(formatNip05Identifier('bob@bob.com')).toBe('bob@bob.com');
+    });
+  });
+
+  describe('NostrProfileContentSchema', () => {
+    it('drops malformed profile properties while retaining valid ones', () => {
+      expect(
+        NostrProfileContentSchema.parse(
+          JSON.stringify({
+            name: 42,
+            display_name: ' Alice ',
+            picture: {},
+            nip05: 'alice+tag@example.com',
+            about: 'Ignored by this schema',
+          })
+        )
+      ).toEqual({ name: '', display_name: 'Alice', picture: '', nip05: '' });
+    });
+
+    it.each(['not json', 'null', '[]'])('rejects invalid profile content: %s', (content) => {
+      expect(NostrProfileContentSchema.safeParse(content).success).toBe(false);
+    });
   });
 
   describe('NostrEventSchema', () => {

--- a/src/lib/search/nostr.ts
+++ b/src/lib/search/nostr.ts
@@ -4,6 +4,63 @@ import { z } from 'zod';
 
 export const PubkeySchema = z.hex().length(64).lowercase();
 
+const NIP05_LOCAL_PART = /^[a-z0-9._-]+$/i;
+
+export const Nip05IdentifierSchema = z.string().superRefine((identifier, ctx) => {
+  const separator = identifier.indexOf('@');
+  if (separator <= 0 || separator !== identifier.lastIndexOf('@')) {
+    ctx.addIssue({ code: 'custom', message: 'Invalid NIP-05 identifier' });
+    return;
+  }
+
+  const localPart = identifier.slice(0, separator);
+  const domain = identifier.slice(separator + 1);
+  if (!NIP05_LOCAL_PART.test(localPart)) {
+    ctx.addIssue({ code: 'custom', message: 'Invalid NIP-05 local part' });
+    return;
+  }
+
+  try {
+    const url = new URL(`https://${domain}`);
+    if (
+      url.host.toLowerCase() !== domain.toLowerCase() ||
+      url.pathname !== '/' ||
+      url.search ||
+      url.hash
+    ) {
+      throw new Error('Invalid NIP-05 domain');
+    }
+  } catch {
+    ctx.addIssue({ code: 'custom', message: 'Invalid NIP-05 domain' });
+  }
+});
+
+const ProfileMetadataStringSchema = z.string().trim().min(1).catch('');
+
+export const NostrProfileMetadataSchema = z.object({
+  name: ProfileMetadataStringSchema,
+  display_name: ProfileMetadataStringSchema,
+  picture: ProfileMetadataStringSchema,
+  nip05: Nip05IdentifierSchema.catch(''),
+});
+
+export type NostrProfileMetadata = z.output<typeof NostrProfileMetadataSchema>;
+
+export const NostrProfileContentSchema = z
+  .string()
+  .transform((content, ctx) => {
+    try {
+      return JSON.parse(content);
+    } catch {
+      ctx.addIssue({ code: 'custom', message: 'Invalid Nostr profile content' });
+      return z.NEVER;
+    }
+  })
+  .pipe(NostrProfileMetadataSchema);
+
+export const formatNip05Identifier = (identifier: string): string =>
+  identifier.startsWith('_@') ? identifier.slice(2) : identifier;
+
 export const NpubSchema = z.string().superRefine((value, ctx) => {
   try {
     const decoded = nip19.decode(value);

--- a/src/lib/stores/profileSuggestions.test.ts
+++ b/src/lib/stores/profileSuggestions.test.ts
@@ -174,4 +174,33 @@ describe('profileSuggestions', () => {
     unsubscribe();
     suggestions.destroy();
   });
+
+  it('ignores malformed properties and formats root NIP-05 identifiers', async () => {
+    vi.useFakeTimers();
+    const suggestions = profileSuggestions({
+      search: vi.fn().mockResolvedValue(
+        result(
+          JSON.stringify({
+            name: 42,
+            display_name: ' Alice ',
+            picture: {},
+            nip05: '_@bob.com',
+          })
+        )
+      ),
+    });
+    let latest: ProfileSuggestionsState = { loading: false, items: [], error: null };
+    const unsubscribe = suggestions.subscribe((state) => {
+      latest = state;
+    });
+
+    suggestions.search('alice');
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(latest.items).toEqual([
+      expect.objectContaining({ name: 'Alice', picture: '', nip05: 'bob.com' }),
+    ]);
+    unsubscribe();
+    suggestions.destroy();
+  });
 });

--- a/src/lib/stores/profileSuggestions.ts
+++ b/src/lib/stores/profileSuggestions.ts
@@ -14,6 +14,11 @@ import {
 } from 'rxjs';
 import { type Readable, writable } from 'svelte/store';
 import { HttpTooManyRequestsError } from '$lib/errors';
+import {
+  formatNip05Identifier,
+  NostrProfileContentSchema,
+  type NostrProfileMetadata,
+} from '$lib/search/nostr';
 import { rateLimitedSearch } from '$lib/search/rate-limited';
 import { createProfileSuggestionRequest } from '$lib/search/request';
 import type { SearchResult } from '$lib/search/result';
@@ -24,6 +29,12 @@ const SEARCH_DEBOUNCE_MS = 250;
 const RATE_LIMIT_MAX_RETRIES = 3;
 const RATE_LIMIT_RETRY_DELAY_MS = 1_000;
 const SEARCH_TIMEOUT_MS = 5_000;
+const emptyProfileMetadata: NostrProfileMetadata = {
+  name: '',
+  display_name: '',
+  picture: '',
+  nip05: '',
+};
 
 export type ProfileSuggestionsState = {
   loading: boolean;
@@ -59,12 +70,21 @@ const retryOnRateLimit = (error: unknown): Observable<number> => {
 };
 
 const parseMentionItem = (pubkey: string, content: string): MentionItem => {
-  try {
-    const { name, display_name: displayName, picture, nip05 } = JSON.parse(content);
-    return { pubkey, content, name: name ?? displayName ?? pubkey, picture, nip05 };
-  } catch {
-    return { pubkey, content, name: pubkey, picture: '', nip05: '' };
-  }
+  const profile = NostrProfileContentSchema.safeParse(content);
+  const {
+    name,
+    display_name: displayName,
+    picture,
+    nip05,
+  } = profile.success ? profile.data : emptyProfileMetadata;
+
+  return {
+    pubkey,
+    content,
+    name: name || displayName || pubkey,
+    picture,
+    nip05: formatNip05Identifier(nip05),
+  };
 };
 
 const defaultSearch: ProfileSearch = (query, signal) =>


### PR DESCRIPTION
## Summary

- add shared Zod schemas for kind 0 profile metadata and NIP-05 identifiers
- ignore malformed profile properties without discarding otherwise usable suggestions
- validate NIP-05 local parts and display root identifiers such as `_@bob.com` as `bob.com`
- add coverage for malformed content, malformed properties, and root NIP-05 formatting

## Testing

- `npx vitest run src/lib/search/nostr.test.ts src/lib/stores/profileSuggestions.test.ts`
- `npm run check`
- `npm run lint`
