### PR TITLE
fix(note): validate profile metadata

### DIFF
--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -2,6 +2,7 @@
   import type * as Nostr from 'nostr-typedef';
   import { inlineImage } from '$lib/actions/inlineImage';
   import { linkify, linkifyOpts } from '$lib/actions/linkify';
+  import { NostrProfileContentSchema, type NostrProfileMetadata } from '$lib/search/nostr';
   import NoteListItemMenu from './NoteListItemMenu.svelte';
   import ProfileAvatar from './ProfileAvatar.svelte';
 
@@ -13,12 +14,15 @@
   let { note, profile }: Props = $props();
 
   const shorten = (id: string) => `${id.substring(0, 9)}:${id.substring(id.length - 8, id.length)}`;
+  const parseProfileMetadata = (content: string): NostrProfileMetadata | undefined => {
+    const parsed = NostrProfileContentSchema.safeParse(content);
+    return parsed.success ? parsed.data : undefined;
+  };
 
-  let profileContent = $derived(profile ? JSON.parse(profile.content) : undefined);
-  let displayName =
-    $derived(profileContent?.display_name ? profileContent.display_name : undefined);
-  let profileName = $derived(profileContent?.name ? profileContent.name : undefined);
-  let nameOrPubkey = $derived(displayName ?? profileName ?? shorten(note.pubkey));
+  let profileMetadata = $derived(profile ? parseProfileMetadata(profile.content) : undefined);
+  let nameOrPubkey = $derived(
+    profileMetadata?.name || profileMetadata?.display_name || shorten(note.pubkey)
+  );
 
   let noteContent = $derived(note.content
     ?.replaceAll(/nostr:npub1([a-z0-9]{58})/g, '@npub1$1')
@@ -31,7 +35,7 @@
   <div class="p-4">
     <div class="flex justify-between items-center">
       <div class="mr-2 flex-none">
-        <ProfileAvatar picture={profileContent?.picture} name={nameOrPubkey} />
+        <ProfileAvatar picture={profileMetadata?.picture ?? ''} name={nameOrPubkey} />
       </div>
 
       <p class="flex-auto font-bold min-w-0 text-ellipsis overflow-hidden">

--- a/src/lib/components/NoteListItem.test.ts
+++ b/src/lib/components/NoteListItem.test.ts
@@ -1,0 +1,65 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import NoteListItem from './NoteListItem.svelte';
+
+const note = {
+  id: 'a'.repeat(64),
+  pubkey: 'b'.repeat(64),
+  created_at: 1_700_000_000,
+  kind: 1,
+  tags: [],
+  content: 'A note',
+  sig: 'c'.repeat(128),
+};
+
+const profile = (content: string) => ({
+  id: 'd'.repeat(64),
+  pubkey: note.pubkey,
+  created_at: 1_700_000_001,
+  kind: 0,
+  tags: [],
+  content,
+  sig: 'e'.repeat(128),
+});
+
+describe('NoteListItem', () => {
+  it('uses the same name and picture fallbacks as profile suggestions', () => {
+    const { container } = render(NoteListItem, {
+      props: {
+        note,
+        profile: profile(JSON.stringify({ name: 42, display_name: ' Alice ', picture: {} })),
+      },
+    });
+
+    expect(container).toHaveTextContent('Alice');
+    expect(container.querySelector('img')).toHaveAttribute('hidden');
+  });
+
+  it('prefers name and renders a valid profile picture', () => {
+    const { container } = render(NoteListItem, {
+      props: {
+        note,
+        profile: profile(
+          JSON.stringify({
+            name: 'Alice',
+            display_name: 'Different name',
+            picture: 'https://example.com/alice.png',
+          })
+        ),
+      },
+    });
+
+    expect(container).toHaveTextContent('Alice');
+    expect(container).not.toHaveTextContent('Different name');
+    expect(container.querySelector('img')).toHaveAttribute('src', 'https://example.com/alice.png');
+  });
+
+  it('falls back to a shortened pubkey when profile content is malformed', () => {
+    const { container } = render(NoteListItem, {
+      props: { note, profile: profile('{not valid json') },
+    });
+
+    expect(container).toHaveTextContent('bbbbbbbbb:bbbbbbbb');
+    expect(container.querySelector('img')).toHaveAttribute('hidden');
+  });
+});


### PR DESCRIPTION
## Summary

- parse kind 0 profile metadata in `NoteListItem` with the shared Zod schema
- apply the same name and avatar fallbacks used by profile suggestions
- prevent malformed metadata content from breaking note rendering
- add component coverage for valid, malformed, and partially invalid profile metadata

## Testing

- `npm test`
- `npm run check`
- `npm run lint`
