### PR TITLE
refactor(profile): normalize mention items

### DIFF
--- a/src/lib/stores/profileSuggestions.ts
+++ b/src/lib/stores/profileSuggestions.ts
@@ -1,4 +1,3 @@
-import type * as Nostr from 'nostr-typedef';
 import {
   catchError,
   distinctUntilChanged,
@@ -14,27 +13,16 @@ import {
 } from 'rxjs';
 import { type Readable, writable } from 'svelte/store';
 import { HttpTooManyRequestsError } from '$lib/errors';
-import {
-  formatNip05Identifier,
-  NostrProfileContentSchema,
-  type NostrProfileMetadata,
-} from '$lib/search/nostr';
 import { rateLimitedSearch } from '$lib/search/rate-limited';
 import { createProfileSuggestionRequest } from '$lib/search/request';
 import type { SearchResult } from '$lib/search/result';
-import type { MentionItem } from '$lib/types';
+import { type MentionItem, MentionItemSchema } from '$lib/types';
 
 const MENU_ITEM_LIMIT = 10;
 const SEARCH_DEBOUNCE_MS = 250;
 const RATE_LIMIT_MAX_RETRIES = 3;
 const RATE_LIMIT_RETRY_DELAY_MS = 1_000;
 const SEARCH_TIMEOUT_MS = 5_000;
-const emptyProfileMetadata: NostrProfileMetadata = {
-  name: '',
-  display_name: '',
-  picture: '',
-  nip05: '',
-};
 
 export type ProfileSuggestionsState = {
   loading: boolean;
@@ -67,24 +55,6 @@ const retryOnRateLimit = (error: unknown): Observable<number> => {
   }
 
   throw error;
-};
-
-const parseMentionItem = (pubkey: string, content: string): MentionItem => {
-  const profile = NostrProfileContentSchema.safeParse(content);
-  const {
-    name,
-    display_name: displayName,
-    picture,
-    nip05,
-  } = profile.success ? profile.data : emptyProfileMetadata;
-
-  return {
-    pubkey,
-    content,
-    name: name || displayName || pubkey,
-    picture,
-    nip05: formatNip05Identifier(nip05),
-  };
 };
 
 const defaultSearch: ProfileSearch = (query, signal) =>
@@ -135,9 +105,7 @@ export const profileSuggestions = (options: Options = {}): ProfileSuggestions =>
             )
           ),
           map((result) =>
-            result.data
-              .map(({ pubkey, content }: Nostr.Event) => parseMentionItem(pubkey, content))
-              .slice(0, MENU_ITEM_LIMIT)
+            result.data.map((event) => MentionItemSchema.parse(event)).slice(0, MENU_ITEM_LIMIT)
           ),
           catchError((error: unknown) => {
             state.set({

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { MentionItemSchema } from './types';
+
+const pubkey = 'a'.repeat(64);
+
+describe('MentionItemSchema', () => {
+  it('normalizes profile metadata for display', () => {
+    expect(
+      MentionItemSchema.parse({
+        pubkey,
+        content: JSON.stringify({
+          name: ' Alice ',
+          display_name: 'Different name',
+          picture: 'https://example.com/alice.png',
+          nip05: '_@example.com',
+        }),
+      })
+    ).toEqual({
+      pubkey,
+      content: JSON.stringify({
+        name: ' Alice ',
+        display_name: 'Different name',
+        picture: 'https://example.com/alice.png',
+        nip05: '_@example.com',
+      }),
+      name: 'Alice',
+      picture: 'https://example.com/alice.png',
+      nip05: 'example.com',
+    });
+  });
+
+  it('falls back to safe display values for malformed profile content', () => {
+    expect(MentionItemSchema.parse({ pubkey, content: '{not valid json' })).toEqual({
+      pubkey,
+      content: '{not valid json',
+      name: pubkey,
+      picture: '',
+      nip05: '',
+    });
+  });
+
+  it('drops malformed profile properties while retaining valid ones', () => {
+    expect(
+      MentionItemSchema.parse({
+        pubkey,
+        content: JSON.stringify({ name: 42, display_name: ' Alice ', picture: {}, nip05: 'bad' }),
+      })
+    ).toEqual({
+      pubkey,
+      content: JSON.stringify({ name: 42, display_name: ' Alice ', picture: {}, nip05: 'bad' }),
+      name: 'Alice',
+      picture: '',
+      nip05: '',
+    });
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,10 @@
+import { z } from 'zod';
+import {
+  formatNip05Identifier,
+  NostrProfileContentSchema,
+  NostrProfileMetadataSchema,
+  PubkeySchema,
+} from '$lib/search/nostr';
 import type { SearchResult } from '$lib/search/result';
 
 export type { SearchResult, SearchResultPagination } from '$lib/search/result';
@@ -13,10 +20,25 @@ export type Profile = Partial<{
   name: string;
 }>;
 
-export type MentionItem = {
-  pubkey: string;
-  content: string;
-  name: string;
-  picture: string;
-  nip05: string;
-};
+const NostrProfileContentWithFallbackSchema = NostrProfileContentSchema.catch(
+  NostrProfileMetadataSchema.parse({})
+);
+
+export const MentionItemSchema = z
+  .object({
+    pubkey: PubkeySchema,
+    content: z.string(),
+  })
+  .transform(({ pubkey, content }) => {
+    const profile = NostrProfileContentWithFallbackSchema.parse(content);
+
+    return {
+      pubkey,
+      content,
+      name: profile.name || profile.display_name || pubkey,
+      picture: profile.picture,
+      nip05: formatNip05Identifier(profile.nip05),
+    };
+  });
+
+export type MentionItem = z.output<typeof MentionItemSchema>;


### PR DESCRIPTION
## Summary

- add a Zod schema for normalized mention items
- centralize malformed profile-content fallback in the mention-item transformation
- remove profile parsing and empty metadata fallback state from `profileSuggestions`
- derive the `MentionItem` type from its schema
- add direct coverage for normalized, malformed, and partially invalid profile metadata

## Testing

- `npm test`
- `npm run check`
- `npm run lint`
