### PR TITLE
feat: verify NIP-05 identifiers and show a badge

### DIFF
--- a/src/lib/components/MentionMenu.svelte
+++ b/src/lib/components/MentionMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { usePopover } from '@skeletonlabs/skeleton-svelte';
   import type { MentionItem } from '$lib/types';
+  import Nip05Badge from './Nip05Badge.svelte';
   import ProfileAvatar from './ProfileAvatar.svelte';
 
   type AnchorRect = { x?: number; y?: number; width?: number; height?: number };
@@ -82,9 +83,12 @@
               onclick={() => onSelect(item)}
             >
               <ProfileAvatar picture={item.picture} name={item.name} class="w-6 h-6 shrink-0" />
-              <span class="truncate">{item.name}</span>
+              <span class="truncate shrink-0">{item.name}</span>
               {#if item.nip05}
-                <span class="truncate"><code class="code">{item.nip05}</code></span>
+                <span class="min-w-0 flex-1 truncate flex items-center gap-1">
+                  <code class="code truncate">{item.nip05}</code>
+                  <Nip05Badge pubkey={item.pubkey} nip05={item.nip05} />
+                </span>
               {/if}
             </button>
           </li>

--- a/src/lib/components/MentionMenu.test.ts
+++ b/src/lib/components/MentionMenu.test.ts
@@ -3,6 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 import type { MentionItem } from '$lib/types';
 import MentionMenu from './MentionMenu.svelte';
 
+// Nip05Badge fetches over the network to verify NIP-05 identifiers; stub out
+// verifyNip05 so these tests stay hermetic and only exercise the menu itself,
+// while keeping the real splitIdentifier for the badge's tooltip text.
+vi.mock('$lib/nip05', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/nip05')>()),
+  verifyNip05: vi.fn(() => new Promise(() => {})),
+}));
+
 const makeItem = (overrides: Partial<MentionItem> = {}): MentionItem => ({
   pubkey: 'pubkey1',
   content: '{}',

--- a/src/lib/components/Nip05Badge.svelte
+++ b/src/lib/components/Nip05Badge.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { faCircleCheck, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+  import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+  import { splitIdentifier, verifyNip05 } from '$lib/nip05';
+
+  interface Props {
+    pubkey: string;
+    nip05: string;
+  }
+
+  let { pubkey, nip05 }: Props = $props();
+
+  type Status = 'pending' | 'verified' | 'failed';
+  let status = $state<Status>('pending');
+  let domain = $derived(nip05 ? splitIdentifier(nip05).domain : '');
+
+  $effect(() => {
+    // Re-read here (not just in the async callback below) so `$effect`
+    // re-runs whenever `pubkey`/`nip05` change.
+    const currentPubkey = pubkey;
+    const currentNip05 = nip05;
+    status = 'pending';
+
+    if (!currentNip05) {
+      return;
+    }
+
+    let cancelled = false;
+    verifyNip05(currentPubkey, currentNip05).then((verified) => {
+      if (!cancelled) {
+        status = verified ? 'verified' : 'failed';
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+</script>
+
+{#if status === 'verified'}
+  <span title="Verified: this account owns {domain}">
+    <FontAwesomeIcon icon={faCircleCheck} class="text-primary-500 shrink-0" />
+  </span>
+{:else if status === 'failed'}
+  <span title="Could not verify this account owns {domain}">
+    <FontAwesomeIcon icon={faCircleXmark} class="text-error-500 shrink-0" />
+  </span>
+{/if}

--- a/src/lib/components/Nip05Badge.test.ts
+++ b/src/lib/components/Nip05Badge.test.ts
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { verifyNip05 } from '$lib/nip05';
+import Nip05Badge from './Nip05Badge.svelte';
+
+vi.mock('$lib/nip05', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/nip05')>()),
+  verifyNip05: vi.fn(),
+}));
+
+const mockedVerifyNip05 = vi.mocked(verifyNip05);
+
+describe('Nip05Badge', () => {
+  beforeEach(() => {
+    mockedVerifyNip05.mockReset();
+  });
+
+  it('shows nothing while verification is pending', () => {
+    mockedVerifyNip05.mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(Nip05Badge, {
+      props: { pubkey: 'pk', nip05: 'alice@example.com' },
+    });
+
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('shows a check icon with a domain-confirming tooltip once verification succeeds', async () => {
+    mockedVerifyNip05.mockResolvedValue(true);
+
+    const { container } = render(Nip05Badge, {
+      props: { pubkey: 'pk', nip05: 'alice@example.com' },
+    });
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('svg[data-icon="circle-check"]')).not.toBeNull();
+    });
+    expect(container.querySelector('[title]')).toHaveAttribute(
+      'title',
+      'Verified: this account owns example.com'
+    );
+    expect(mockedVerifyNip05).toHaveBeenCalledExactlyOnceWith('pk', 'alice@example.com');
+  });
+
+  it('shows a failure icon with a domain-referencing tooltip once verification fails', async () => {
+    mockedVerifyNip05.mockResolvedValue(false);
+
+    const { container } = render(Nip05Badge, {
+      props: { pubkey: 'pk', nip05: 'alice@example.com' },
+    });
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('svg[data-icon="circle-xmark"]')).not.toBeNull();
+    });
+    expect(container.querySelector('[title]')).toHaveAttribute(
+      'title',
+      'Could not verify this account owns example.com'
+    );
+  });
+
+  it('does not verify when nip05 is empty', () => {
+    render(Nip05Badge, { props: { pubkey: 'pk', nip05: '' } });
+
+    expect(mockedVerifyNip05).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import type * as Nostr from 'nostr-typedef';
+  import { zostr } from 'zod-nostr';
   import { inlineImage } from '$lib/actions/inlineImage';
   import { linkify, linkifyOpts } from '$lib/actions/linkify';
   import { NostrProfileContentSchema, type NostrProfileMetadata } from '$lib/profile';
+  import Nip05Badge from './Nip05Badge.svelte';
   import NoteListItemMenu from './NoteListItemMenu.svelte';
   import ProfileAvatar from './ProfileAvatar.svelte';
 
@@ -38,8 +40,14 @@
         <ProfileAvatar picture={profileMetadata?.picture ?? ''} name={nameOrPubkey} />
       </div>
 
-      <p class="flex-auto font-bold min-w-0 text-ellipsis overflow-hidden">
-        {nameOrPubkey}
+      <p class="flex-auto min-w-0 flex items-center gap-1">
+        <span class="font-bold truncate shrink-0">{nameOrPubkey}</span>
+        {#if profileMetadata?.nip05}
+          <span class="min-w-0 flex-1 truncate flex items-center gap-1">
+            <code class="code truncate">{zostr.nip05.formatIdentifier(profileMetadata.nip05)}</code>
+            <Nip05Badge pubkey={note.pubkey} nip05={profileMetadata.nip05} />
+          </span>
+        {/if}
       </p>
 
       <NoteListItemMenu {note} />

--- a/src/lib/components/NoteListItem.test.ts
+++ b/src/lib/components/NoteListItem.test.ts
@@ -1,6 +1,19 @@
 import { render } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { verifyNip05 } from '$lib/nip05';
 import NoteListItem from './NoteListItem.svelte';
+
+vi.mock('$lib/nip05', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/nip05')>()),
+  verifyNip05: vi.fn(),
+}));
+
+const mockedVerifyNip05 = vi.mocked(verifyNip05);
+
+beforeEach(() => {
+  mockedVerifyNip05.mockReset();
+  mockedVerifyNip05.mockReturnValue(new Promise(() => {}));
+});
 
 const note = {
   id: 'a'.repeat(64),
@@ -61,5 +74,43 @@ describe('NoteListItem', () => {
 
     expect(container).toHaveTextContent('bbbbbbbbb:bbbbbbbb');
     expect(container.querySelector('img')).toHaveAttribute('hidden');
+  });
+
+  it('shows the nip05 identifier and verifies it, displaying a check icon once confirmed', async () => {
+    mockedVerifyNip05.mockResolvedValue(true);
+
+    const { container } = render(NoteListItem, {
+      props: {
+        note,
+        profile: profile(JSON.stringify({ name: 'Alice', nip05: 'alice@example.com' })),
+      },
+    });
+
+    expect(container.querySelector('code')?.textContent).toBe('alice@example.com');
+    expect(mockedVerifyNip05).toHaveBeenCalledExactlyOnceWith(note.pubkey, 'alice@example.com');
+    await vi.waitFor(() => {
+      expect(container.querySelector('svg[data-icon="circle-check"]')).not.toBeNull();
+    });
+  });
+
+  it('strips the "_@" local part when displaying a domain-only nip05 identifier', () => {
+    const { container } = render(NoteListItem, {
+      props: {
+        note,
+        profile: profile(JSON.stringify({ name: 'Alice', nip05: '_@example.com' })),
+      },
+    });
+
+    expect(container.querySelector('code')?.textContent).toBe('example.com');
+    expect(mockedVerifyNip05).toHaveBeenCalledExactlyOnceWith(note.pubkey, '_@example.com');
+  });
+
+  it('does not show a nip05 identifier or verify when absent from the profile', () => {
+    const { container } = render(NoteListItem, {
+      props: { note, profile: profile(JSON.stringify({ name: 'Alice' })) },
+    });
+
+    expect(container.querySelector('code')).toBeNull();
+    expect(mockedVerifyNip05).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/nip05.test.ts
+++ b/src/lib/nip05.test.ts
@@ -1,0 +1,111 @@
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { verifyNip05 } from './nip05';
+
+const server = setupServer();
+
+const pubkey = 'a'.repeat(64);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('verifyNip05', () => {
+  it('resolves true when the domain vouches for the pubkey', async () => {
+    server.use(
+      http.get('https://valid.example/.well-known/nostr.json', ({ request }) => {
+        expect(new URL(request.url).searchParams.get('name')).toBe('alice');
+        return HttpResponse.json({ names: { alice: pubkey } });
+      })
+    );
+
+    await expect(verifyNip05(pubkey, 'alice@valid.example')).resolves.toBe(true);
+  });
+
+  it('resolves false when the domain maps the name to a different pubkey', async () => {
+    server.use(
+      http.get('https://mismatch.example/.well-known/nostr.json', () =>
+        HttpResponse.json({ names: { alice: 'b'.repeat(64) } })
+      )
+    );
+
+    await expect(verifyNip05(pubkey, 'alice@mismatch.example')).resolves.toBe(false);
+  });
+
+  it('resolves false when the name is absent from the document', async () => {
+    server.use(
+      http.get('https://absent.example/.well-known/nostr.json', () =>
+        HttpResponse.json({ names: {} })
+      )
+    );
+
+    await expect(verifyNip05(pubkey, 'alice@absent.example')).resolves.toBe(false);
+  });
+
+  it('resolves false on a non-2xx response', async () => {
+    server.use(
+      http.get(
+        'https://not-found.example/.well-known/nostr.json',
+        () => new HttpResponse(null, { status: 404 })
+      )
+    );
+
+    await expect(verifyNip05(pubkey, 'alice@not-found.example')).resolves.toBe(false);
+  });
+
+  it('resolves false on a malformed document', async () => {
+    server.use(
+      http.get('https://malformed.example/.well-known/nostr.json', () =>
+        HttpResponse.json({ oops: true })
+      )
+    );
+
+    await expect(verifyNip05(pubkey, 'alice@malformed.example')).resolves.toBe(false);
+  });
+
+  it('resolves false on a network error', async () => {
+    server.use(
+      http.get('https://unreachable.example/.well-known/nostr.json', () => HttpResponse.error())
+    );
+
+    await expect(verifyNip05(pubkey, 'alice@unreachable.example')).resolves.toBe(false);
+  });
+
+  it('queries the "_" local part for a domain-only identifier', async () => {
+    server.use(
+      http.get('https://domain-only.example/.well-known/nostr.json', ({ request }) => {
+        expect(new URL(request.url).searchParams.get('name')).toBe('_');
+        return HttpResponse.json({ names: { _: pubkey } });
+      })
+    );
+
+    await expect(verifyNip05(pubkey, 'domain-only.example')).resolves.toBe(true);
+  });
+
+  it('queries the "_" local part for an unformatted domain-root identifier', async () => {
+    server.use(
+      http.get('https://domain-root.example/.well-known/nostr.json', ({ request }) => {
+        expect(new URL(request.url).searchParams.get('name')).toBe('_');
+        return HttpResponse.json({ names: { _: pubkey } });
+      })
+    );
+
+    await expect(verifyNip05(pubkey, '_@domain-root.example')).resolves.toBe(true);
+  });
+
+  it('caches successful verifications so a repeat call does not refetch', async () => {
+    let requestCount = 0;
+    server.use(
+      http.get('https://cache.example/.well-known/nostr.json', () => {
+        requestCount += 1;
+        return HttpResponse.json({ names: { alice: pubkey } });
+      })
+    );
+
+    await verifyNip05(pubkey, 'alice@cache.example');
+    await verifyNip05(pubkey, 'alice@cache.example');
+
+    expect(requestCount).toBe(1);
+  });
+});

--- a/src/lib/nip05.ts
+++ b/src/lib/nip05.ts
@@ -1,0 +1,59 @@
+import { zostr } from 'zod-nostr';
+import { browser } from '$app/environment';
+
+const VERIFY_TIMEOUT_MS = 5_000;
+
+const cache = new Map<string, Promise<boolean>>();
+
+// Exported so callers (e.g. Nip05Badge) can show which domain a check was
+// performed against without duplicating the "no `@`" => domain-root fallback.
+export const splitIdentifier = (identifier: string): { localPart: string; domain: string } => {
+  const at = identifier.lastIndexOf('@');
+  return at === -1
+    ? { localPart: '_', domain: identifier }
+    : { localPart: identifier.slice(0, at), domain: identifier.slice(at + 1) };
+};
+
+async function fetchAndVerify(pubkey: string, identifier: string): Promise<boolean> {
+  const { localPart, domain } = splitIdentifier(identifier);
+
+  try {
+    const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(localPart)}`;
+    const response = await fetch(url, { signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS) });
+    if (!response.ok) {
+      return false;
+    }
+
+    const parsed = zostr.nip05.nostrJsonDocument().safeParse(await response.json());
+    if (!parsed.success) {
+      return false;
+    }
+
+    const resolvedPubkey = parsed.data.names[localPart];
+    return resolvedPubkey?.toLowerCase() === pubkey.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+// Verifies that `identifier`'s domain vouches for `pubkey` per NIP-05, by
+// fetching and checking its `.well-known/nostr.json`. Callers may pass either
+// the raw profile identifier or the display form with a leading `_@`
+// stripped (see `zostr.nip05.formatIdentifier`) -- both resolve to the same
+// local part here. Results are cached per pubkey+identifier for the life of
+// the page so the same profile showing up repeatedly (mention suggestions,
+// search results) only triggers one fetch per domain.
+export function verifyNip05(pubkey: string, identifier: string): Promise<boolean> {
+  if (!browser) {
+    return Promise.resolve(false);
+  }
+
+  const key = `${pubkey}:${identifier}`;
+  let cached = cache.get(key);
+  if (!cached) {
+    cached = fetchAndVerify(pubkey, identifier);
+    cache.set(key, cached);
+  }
+
+  return cached;
+}


### PR DESCRIPTION
## Summary
- Verifies a profile's NIP-05 identifier against its `.well-known/nostr.json` (via a cached `verifyNip05` helper) and shows a check/failure badge with a hover tooltip naming the domain once verification resolves.
- Wired into the MentionMenu suggestion list and the search results note list.
- Search results now also show the NIP-05 identifier next to the author's name (stripping the `_@` local part for domain-only identifiers, matching MentionMenu), with the identifier truncating before the name when space is tight.

## Test plan
- [x] `npm test` (94 tests passing)
- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npm run lint` (biome)
- [x] Manually verified in a running dev server against live search results: badge renders, hover tooltip shows via `getByTitle`, domain-only identifiers display correctly