### PR TITLE
feat: collapse long search-result posts with Skeleton's Collapsible

### DIFF
--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Collapsible } from '@skeletonlabs/skeleton-svelte';
   import type * as Nostr from 'nostr-typedef';
   import { zostr } from 'zod-nostr';
   import { inlineImage } from '$lib/actions/inlineImage';
@@ -14,6 +15,21 @@
   }
 
   let { note, profile }: Props = $props();
+
+  // Roughly the height of 8 lines of body text (the old line-clamp-8 behavior).
+  const COLLAPSED_HEIGHT = 192;
+  // Only posts past this length get wrapped in a Collapsible. Deciding this from
+  // the raw content length (rather than measuring rendered height) keeps short
+  // posts from ever being forced to the collapsed height: Skeleton's Collapsible
+  // sets min-height *and* max-height to `collapsedHeight` while closed, which
+  // would otherwise pad every short post out to the same fixed height.
+  const LONG_CONTENT_THRESHOLD = 500;
+  // Text length alone misses image-only (or short-caption, tall-image) posts,
+  // since the embedded image that inflates the rendered height isn't reflected
+  // in the character count. Same extensions inlineImage looks for.
+  const IMAGE_URL_PATTERN = /https?:\/\/\S+\.(?:jpe?g|png|gif|webp)\b/i;
+
+  let isExpanded = $state(false);
 
   const shorten = (id: string) => `${id.substring(0, 9)}:${id.substring(id.length - 8, id.length)}`;
   const parseProfileMetadata = (content: string): NostrProfileMetadata | undefined => {
@@ -31,7 +47,23 @@
     ?.replaceAll(/nostr:nprofile1([a-z0-9]{61,})/g, '@nprofile1$1')
     ?.replaceAll(/nostr:note1([a-z0-9]{58})/g, '@note1$1')
     ?.replaceAll(/nostr:nevent1([a-z0-9]{70,})/g, '@nevent1$1'));
+  let isLongContent = $derived(
+    (noteContent?.length ?? 0) > LONG_CONTENT_THRESHOLD || IMAGE_URL_PATTERN.test(note.content ?? '')
+  );
 </script>
+
+{#snippet noteContentParagraph(className: string)}
+  <p
+    use:inlineImage={{
+      className: 'my-4 w-full max-w-lg',
+      attributes: { alt: 'Embed image', decoding: 'async', loading: 'lazy' },
+    }}
+    use:linkify={linkifyOpts}
+    class={className}
+  >
+    {noteContent}
+  </p>
+{/snippet}
 
 <div class="card preset-tonal-surface">
   <div class="p-4">
@@ -53,16 +85,25 @@
       <NoteListItemMenu {note} />
     </div>
 
-    <p
-      use:inlineImage={{
-        className: 'my-4 w-full max-w-lg',
-        attributes: { alt: 'Embed image', decoding: 'async', loading: 'lazy' },
-      }}
-      use:linkify={linkifyOpts}
-      class="text-ellipsis overflow-hidden line-clamp-8 mt-4"
-    >
-      {noteContent}
-    </p>
+    {#if isLongContent}
+      <Collapsible
+        defaultOpen={false}
+        collapsedHeight={COLLAPSED_HEIGHT}
+        onOpenChange={(e) => (isExpanded = e.open)}
+        class="mt-4"
+      >
+        <Collapsible.Content
+          class="w-full min-w-0 overflow-hidden transition-[height] duration-300 ease-in-out data-[state=closed]:h-(--collapsed-height) data-[state=open]:h-(--height)"
+        >
+          {@render noteContentParagraph('')}
+        </Collapsible.Content>
+        <Collapsible.Trigger class="btn btn-sm preset-tonal-surface mt-2">
+          {isExpanded ? 'Show less' : 'Show more'}
+        </Collapsible.Trigger>
+      </Collapsible>
+    {:else}
+      {@render noteContentParagraph('mt-4')}
+    {/if}
   </div>
 
   <hr />

--- a/src/lib/components/NoteListItem.test.ts
+++ b/src/lib/components/NoteListItem.test.ts
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { verifyNip05 } from '$lib/nip05';
 import NoteListItem from './NoteListItem.svelte';
@@ -112,5 +112,49 @@ describe('NoteListItem', () => {
 
     expect(container.querySelector('code')).toBeNull();
     expect(mockedVerifyNip05).not.toHaveBeenCalled();
+  });
+
+  describe('long-post collapsing', () => {
+    const withContent = (content: string) => ({ ...note, content });
+
+    it('does not show a "Show more" trigger for short posts', () => {
+      const { queryByRole } = render(NoteListItem, {
+        props: { note: withContent('A short note'), profile: undefined },
+      });
+
+      expect(queryByRole('button', { name: 'Show more' })).toBeNull();
+    });
+
+    it('shows a "Show more" trigger for posts past the length threshold', () => {
+      const { getByRole } = render(NoteListItem, {
+        props: { note: withContent('a'.repeat(600)), profile: undefined },
+      });
+
+      expect(getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+    });
+
+    it('shows a "Show more" trigger for short-caption posts with an embedded image', () => {
+      const { getByRole } = render(NoteListItem, {
+        props: {
+          note: withContent('Check this out https://example.com/photo.png'),
+          profile: undefined,
+        },
+      });
+
+      expect(getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+    });
+
+    it('toggles the trigger label between "Show more" and "Show less" when clicked', async () => {
+      const { getByRole } = render(NoteListItem, {
+        props: { note: withContent('a'.repeat(600)), profile: undefined },
+      });
+
+      const trigger = getByRole('button', { name: 'Show more' });
+      await fireEvent.click(trigger);
+      expect(trigger).toHaveTextContent('Show less');
+
+      await fireEvent.click(trigger);
+      expect(trigger).toHaveTextContent('Show more');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Long posts in search results (and short-caption posts embedding a tall image) now render behind a Skeleton `Collapsible` with a "Show more" / "Show less" trigger, instead of being permanently clamped to 8 lines with no way to expand
- Short posts render as a plain paragraph, so their natural height is never forced to match the collapsed height of longer posts (avoids Skeleton's Collapsible forcing an equal min/max height on every post regardless of content length)
- Fixed a flexbox width bug where an unbreakable long URL inside a collapsed post could push the Collapsible content past the card's edge (`w-full`/`min-w-0` on `Collapsible.Content`)

## Test plan
- [x] `npm run test` — all 94 tests pass, including 4 new tests covering the show/hide trigger logic (short post, long post, image-only post, toggle label)
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run lint` (biome) — 0 warnings
- [x] Manually verified in a browser against live search results: card widths stay uniform, short posts keep their natural height, long/image posts show a working "Show more" → "Show less" toggle