### PR TITLE
fix: wrap unbreakable long tokens in note content instead of overflowing

### DIFF
--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -59,7 +59,7 @@
       attributes: { alt: 'Embed image', decoding: 'async', loading: 'lazy' },
     }}
     use:linkify={linkifyOpts}
-    class={className}
+    class="break-words {className}"
   >
     {noteContent}
   </p>

--- a/src/lib/components/NoteListItem.test.ts
+++ b/src/lib/components/NoteListItem.test.ts
@@ -156,5 +156,18 @@ describe('NoteListItem', () => {
       await fireEvent.click(trigger);
       expect(trigger).toHaveTextContent('Show more');
     });
+
+    it('lets unbreakable long tokens (e.g. an unreplaced nostr: identifier) wrap instead of overflowing the card, for both short and long posts', () => {
+      const shortWithRawIdentifier = withContent(`nostr:nevent1${'q'.repeat(70)}`);
+      const { container: shortContainer } = render(NoteListItem, {
+        props: { note: shortWithRawIdentifier, profile: undefined },
+      });
+      expect(shortContainer.querySelector('p.break-words')).not.toBeNull();
+
+      const { container: longContainer } = render(NoteListItem, {
+        props: { note: withContent('a'.repeat(600)), profile: undefined },
+      });
+      expect(longContainer.querySelector('p.break-words')).not.toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #343: short posts (rendered without the `Collapsible` wrapper) had no protection against long, space-free strings — e.g. a raw `nostr:nevent1...` identifier that the regex substitution didn't match — so the text overflowed visibly past the card's edge instead of wrapping
- Add `break-words` (`overflow-wrap: break-word`) to the note content paragraph so both the plain and `Collapsible`-wrapped rendering paths keep this kind of content contained within the card

## Test plan
- [x] `npm run test` — all 99 tests pass, including a new regression test asserting `break-words` is present on the paragraph for both the short and long/Collapsible rendering paths
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run lint` (biome) — 0 warnings
- [x] Reproduced the overflow in a live browser (`scrollWidth` 2183px vs `clientWidth` 336px on an injected long unbroken token) and confirmed it's resolved after the fix (both now 336px)