### PR TITLE
fix: only collapse image-only posts when their measured height overflows

### DIFF
--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -18,18 +18,17 @@
 
   // Roughly the height of 8 lines of body text (the old line-clamp-8 behavior).
   const COLLAPSED_HEIGHT = 192;
-  // Only posts past this length get wrapped in a Collapsible. Deciding this from
-  // the raw content length (rather than measuring rendered height) keeps short
-  // posts from ever being forced to the collapsed height: Skeleton's Collapsible
-  // sets min-height *and* max-height to `collapsedHeight` while closed, which
-  // would otherwise pad every short post out to the same fixed height.
+  // Posts past this length are confidently long, so they can be collapsed
+  // immediately from the raw content length without measuring rendered height.
   const LONG_CONTENT_THRESHOLD = 500;
   // Text length alone misses image-only (or short-caption, tall-image) posts,
   // since the embedded image that inflates the rendered height isn't reflected
-  // in the character count. Same extensions inlineImage looks for.
+  // in the character count. Same extensions inlineImage looks for. Unlike text
+  // length, an image's rendered height isn't known up front, so these posts
+  // start fully open and only collapse once measured to actually exceed
+  // COLLAPSED_HEIGHT — otherwise a short image would be padded out to a taller
+  // box with a "Show more" trigger that reveals nothing new.
   const IMAGE_URL_PATTERN = /https?:\/\/\S+\.(?:jpe?g|png|gif|webp)\b/i;
-
-  let isExpanded = $state(false);
 
   const shorten = (id: string) => `${id.substring(0, 9)}:${id.substring(id.length - 8, id.length)}`;
   const parseProfileMetadata = (content: string): NostrProfileMetadata | undefined => {
@@ -42,18 +41,60 @@
     profileMetadata?.name || profileMetadata?.display_name || shorten(note.pubkey)
   );
 
-  let noteContent = $derived(note.content
-    ?.replaceAll(/nostr:npub1([a-z0-9]{58})/g, '@npub1$1')
-    ?.replaceAll(/nostr:nprofile1([a-z0-9]{61,})/g, '@nprofile1$1')
-    ?.replaceAll(/nostr:note1([a-z0-9]{58})/g, '@note1$1')
-    ?.replaceAll(/nostr:nevent1([a-z0-9]{70,})/g, '@nevent1$1'));
-  let isLongContent = $derived(
-    (noteContent?.length ?? 0) > LONG_CONTENT_THRESHOLD || IMAGE_URL_PATTERN.test(note.content ?? '')
-  );
+  const transformContent = (content: string | undefined) =>
+    content
+      ?.replaceAll(/nostr:npub1([a-z0-9]{58})/g, '@npub1$1')
+      ?.replaceAll(/nostr:nprofile1([a-z0-9]{61,})/g, '@nprofile1$1')
+      ?.replaceAll(/nostr:note1([a-z0-9]{58})/g, '@note1$1')
+      ?.replaceAll(/nostr:nevent1([a-z0-9]{70,})/g, '@nevent1$1');
+  const isContentDefinitelyLong = (content: string | undefined) =>
+    (transformContent(content)?.length ?? 0) > LONG_CONTENT_THRESHOLD;
+
+  let noteContent = $derived(transformContent(note.content));
+  let isDefinitelyLong = $derived(isContentDefinitelyLong(note.content));
+  let hasImage = $derived(IMAGE_URL_PATTERN.test(note.content ?? ''));
+  let isLongContent = $derived(isDefinitelyLong || hasImage);
+
+  let contentEl: HTMLElement | undefined = $state();
+  // Seeded once from the initial content, not the reactive `isDefinitelyLong`
+  // derived above: `note` never changes identity for a mounted list item, so
+  // there's nothing to resync.
+  // svelte-ignore state_referenced_locally
+  const isDefinitelyLongInitial = isContentDefinitelyLong(note.content);
+  let isOpen = $state(!isDefinitelyLongInitial);
+  let isCollapsing = $state(isDefinitelyLongInitial);
+  let hasAutoCollapsed = false;
+
+  $effect(() => {
+    // Definitely-long posts are already collapsed; only image-only posts need
+    // their real height measured to decide whether to collapse at all.
+    if (!isLongContent || isDefinitelyLong) {
+      return;
+    }
+
+    const el = contentEl;
+    if (!el) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      if (hasAutoCollapsed || el.scrollHeight <= COLLAPSED_HEIGHT) {
+        return;
+      }
+
+      hasAutoCollapsed = true;
+      isCollapsing = true;
+      isOpen = false;
+    });
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  });
 </script>
 
 {#snippet noteContentParagraph(className: string)}
   <p
+    bind:this={contentEl}
     use:inlineImage={{
       className: 'my-4 w-full max-w-lg',
       attributes: { alt: 'Embed image', decoding: 'async', loading: 'lazy' },
@@ -87,19 +128,19 @@
 
     {#if isLongContent}
       <Collapsible
-        defaultOpen={false}
-        collapsedHeight={COLLAPSED_HEIGHT}
-        onOpenChange={(e) => (isExpanded = e.open)}
+        open={isOpen}
+        collapsedHeight={isCollapsing ? COLLAPSED_HEIGHT : undefined}
+        onOpenChange={(e) => (isOpen = e.open)}
         class="mt-4"
       >
-        <Collapsible.Content
-          class="w-full min-w-0 overflow-hidden transition-[height] duration-300 ease-in-out data-[state=closed]:h-(--collapsed-height) data-[state=open]:h-(--height)"
-        >
+        <Collapsible.Content class="w-full min-w-0 overflow-hidden">
           {@render noteContentParagraph('')}
         </Collapsible.Content>
-        <Collapsible.Trigger class="btn btn-sm preset-tonal-surface mt-2">
-          {isExpanded ? 'Show less' : 'Show more'}
-        </Collapsible.Trigger>
+        {#if isCollapsing}
+          <Collapsible.Trigger class="btn btn-sm preset-tonal-surface mt-2">
+            {isOpen ? 'Show less' : 'Show more'}
+          </Collapsible.Trigger>
+        {/if}
       </Collapsible>
     {:else}
       {@render noteContentParagraph('mt-4')}

--- a/src/lib/components/NoteListItem.test.ts
+++ b/src/lib/components/NoteListItem.test.ts
@@ -133,15 +133,23 @@ describe('NoteListItem', () => {
       expect(getByRole('button', { name: 'Show more' })).toBeInTheDocument();
     });
 
-    it('shows a "Show more" trigger for short-caption posts with an embedded image', () => {
-      const { getByRole } = render(NoteListItem, {
+    it('does not show a "Show more" trigger for a short-caption post with an image until its rendered height is measured to overflow', () => {
+      // jsdom doesn't lay out elements, so the ResizeObserver that would
+      // normally reveal the trigger for a tall image never fires here. That's
+      // the point: a short image must never get a trigger it doesn't need
+      // (regression test for it being padded out to a fixed height with a
+      // trigger that revealed nothing), and confirming this measurement path
+      // is skipped in this environment is as far as a unit test can go —
+      // whether a genuinely tall image later reveals the trigger is a
+      // layout-dependent behavior verified manually in a real browser.
+      const { queryByRole } = render(NoteListItem, {
         props: {
           note: withContent('Check this out https://example.com/photo.png'),
           profile: undefined,
         },
       });
 
-      expect(getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+      expect(queryByRole('button', { name: 'Show more' })).toBeNull();
     });
 
     it('toggles the trigger label between "Show more" and "Show less" when clicked', async () => {


### PR DESCRIPTION
## Summary
- Follow-up to #343/#344 — reported case: `from:npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6` on mobile width, 2nd post
- Posts flagged as "long" solely because they embed an image were always collapsed to a fixed 192px box with a "Show more" trigger, even when the rendered image was shorter than 192px — the trigger revealed nothing when clicked, and the box was padded out with empty space below a small image
- Posts confidently known to be long from their text length (> 500 chars) are collapsed immediately, same as before
- Posts flagged only by an embedded image now render fully open at their natural height, and only collapse (revealing a trigger) once a `ResizeObserver` confirms the rendered content actually exceeds 192px

## Test plan
- [x] `npm run test` — all 99 tests pass; updated the image-post test to assert no trigger appears without a real overflow measurement (jsdom can't lay out elements, so this also serves as a regression test for the reported bug — a short image must never get a padded box + useless trigger)
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run lint` (biome) — 0 warnings
- [x] Reproduced the reported post in a live browser at mobile width (400px): before the fix the card was 395px tall with an empty gap and a "Show more" that changed nothing; after the fix it's 352px with no trigger, matching the image's natural size
- [x] Re-verified across the full "nostr" search result set (204 cards): all cards stay the same width (no overflow regression), 30 image posts total — 9 correctly still show "Show more" (confirmed by expanding each: heights grow from 395px to 480–10679px, i.e. genuinely tall), 21 correctly show no trigger at natural heights (225–321px)
- [x] Confirmed text-length-triggered long posts (no image) still collapse immediately and toggle correctly (Show more → Show less → Show more round-trip)