### PR TITLE
fix: resolve mobile layout overflow in search results

### DIFF
--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -117,7 +117,7 @@
         <span class="font-bold truncate shrink-0">{nameOrPubkey}</span>
         {#if profileMetadata?.nip05}
           <span class="min-w-0 flex-1 truncate flex items-center gap-1">
-            <code class="code truncate">{zostr.nip05.formatIdentifier(profileMetadata.nip05)}</code>
+            <code class="code truncate overflow-x-hidden!">{zostr.nip05.formatIdentifier(profileMetadata.nip05)}</code>
             <Nip05Badge pubkey={note.pubkey} nip05={profileMetadata.nip05} />
           </span>
         {/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -132,7 +132,7 @@
       pageSize={data.result.pagination.limit}
       page={data.page + 1}
       onPageChange={(e) => handlePage(e.page - 1)}
-      class="mx-auto w-fit flex gap-1"
+      class="mx-auto w-fit max-w-full flex flex-wrap justify-center gap-1"
     >
       <Pagination.PrevTrigger class="btn-icon">&larr;</Pagination.PrevTrigger>
       <Pagination.Context>


### PR DESCRIPTION
## Summary
- Fix nip05 identifiers on the search results screen becoming horizontally scrollable without revealing any additional text — Skeleton's `.code` utility sets `overflow-x: auto`, which was winning the cascade over Tailwind's `truncate` (`overflow: hidden`)
- Fix the search results paginator overflowing the viewport (leaving extra margin) on narrow screens when there are many result pages, by allowing the pagination row to wrap instead of forcing a single non-wrapping row

## Test plan
- [x] `npm run lint`
- [x] `npm run test`
- [x] Verified in a real browser at 320px/375px viewport widths that the nip05 identifier truncates cleanly with no scrollable overflow, and that the paginator wraps onto multiple lines instead of overflowing the viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)