### PR TITLE
fix: long name overlap and excess image top margin in note cards

### DIFF
--- a/src/lib/actions/inlineImage.test.ts
+++ b/src/lib/actions/inlineImage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { inlineImage } from './inlineImage';
+
+const opts = {
+  className: 'my-4 w-full max-w-lg',
+  attributes: { alt: 'Embed image', decoding: 'async', loading: 'lazy' },
+};
+
+const run = (content: string) => {
+  const node = document.createElement('p');
+  node.innerHTML = content;
+  inlineImage(node, opts);
+  return node.innerHTML;
+};
+
+describe('inlineImage', () => {
+  it('replaces an image URL with an img tag', () => {
+    const html = run('https://example.com/photo.jpg');
+
+    expect(html).toContain('<img');
+    expect(html).toContain('src="https://example.com/photo.jpg"');
+  });
+
+  it('strips blank lines directly surrounding an image URL so no extra gap is rendered', () => {
+    // Mirrors how some clients pad an attached image with several blank
+    // lines, which `linkify`'s `nl2br` later turns into visible `<br>`s.
+    const html = run('\n\n\n\nhttps://example.com/photo.jpg');
+
+    expect(html).not.toContain('\n');
+    expect(html.trim().startsWith('<img')).toBe(true);
+  });
+
+  it('strips blank lines after an image URL as well as before it', () => {
+    const html = run('https://example.com/a.jpg\n\n\n\nhttps://example.com/b.jpg');
+
+    expect(html).not.toContain('\n');
+  });
+
+  it('strips blank lines between preceding text and the image', () => {
+    const html = run('GM PV\n\n\n\nhttps://example.com/photo.jpg');
+
+    expect(html).toBe(
+      'GM PV<img alt="Embed image" decoding="async" loading="lazy" src="https://example.com/photo.jpg" class="my-4 w-full max-w-lg">'
+    );
+  });
+
+  it('does not swallow non-newline whitespace separating text from the image', () => {
+    const html = run('GM PV\n\n \n\n\n\nhttps://example.com/photo.jpg');
+
+    expect(html).toContain('GM PV\n\n ');
+    expect(html).not.toMatch(/\n<img/);
+  });
+
+  it('leaves non-image URLs untouched', () => {
+    const html = run('\n\nhttps://example.com/page\n\n');
+
+    expect(html).not.toContain('<img');
+    expect(html).toBe('\n\nhttps://example.com/page\n\n');
+  });
+});

--- a/src/lib/actions/inlineImage.ts
+++ b/src/lib/actions/inlineImage.ts
@@ -34,6 +34,10 @@ function uniq<T>(xs: T[]): T[] {
   return [...new Set(xs)];
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // TODO: Add `Action` type
 export const inlineImage = (node: HTMLElement, opts: Partial<Opts>) => {
   const mergedOpts = { ...defaultOpts, ...opts };
@@ -54,7 +58,13 @@ export const inlineImage = (node: HTMLElement, opts: Partial<Opts>) => {
       class: mergedOpts.className,
     };
     const tag = mergedOpts.render(mergedOpts.tagName, attributes);
-    text = text.replaceAll(urlString, tag);
+    // Newlines directly surrounding the URL are later turned into visible
+    // `<br>`s by the `linkify` action's `nl2br` option. Authors commonly pad
+    // an image URL with several blank lines, which would otherwise leave a
+    // large empty gap above/below the now-inlined image on top of its own
+    // margin.
+    const pattern = new RegExp(`\\n*${escapeRegExp(urlString)}\\n*`, 'g');
+    text = text.replace(pattern, tag);
   });
 
   node.innerHTML = text;

--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -114,7 +114,7 @@
       </div>
 
       <p class="flex-auto min-w-0 flex items-center gap-1">
-        <span class="font-bold truncate shrink-0">{nameOrPubkey}</span>
+        <span class="font-bold truncate min-w-0">{nameOrPubkey}</span>
         {#if profileMetadata?.nip05}
           <span class="min-w-0 flex-1 truncate flex items-center gap-1">
             <code class="code truncate overflow-x-hidden!">{zostr.nip05.formatIdentifier(profileMetadata.nip05)}</code>

--- a/src/lib/components/NoteListItem.test.ts
+++ b/src/lib/components/NoteListItem.test.ts
@@ -114,6 +114,26 @@ describe('NoteListItem', () => {
     expect(mockedVerifyNip05).not.toHaveBeenCalled();
   });
 
+  it('allows a long display name to shrink and truncate instead of overlapping the menu button', () => {
+    // Regression test: the name span previously had `shrink-0`, which kept it
+    // at its full content width inside the flex header row no matter how
+    // little space was left, so a long name rendered on top of the
+    // three-dot menu button instead of truncating. `shrink-0` disables the
+    // very shrinking that `truncate`'s ellipsis relies on, so a real browser
+    // has to size the flex row before this is layout-verifiable; this test
+    // only pins the class contract that makes shrinking possible again.
+    const { container } = render(NoteListItem, {
+      props: {
+        note,
+        profile: profile(JSON.stringify({ name: 'A'.repeat(80) })),
+      },
+    });
+
+    const nameSpan = container.querySelector('span.font-bold');
+    expect(nameSpan).toHaveClass('truncate');
+    expect(nameSpan).not.toHaveClass('shrink-0');
+  });
+
   describe('long-post collapsing', () => {
     const withContent = (content: string) => ({ ...note, content });
 


### PR DESCRIPTION
## Summary
- Fix long display names rendering on top of the note card's three-dot menu button instead of truncating — the name span had `shrink-0`, which kept it at its full content width regardless of available space, defeating the `truncate` ellipsis it was paired with
- Fix inlined images having an unnecessarily large empty gap above them for some posts — some clients pad an attached image URL with several blank lines, which `linkify`'s `nl2br` turns into visible `<br>`s stacked on top of the image's own margin; `inlineImage` now strips newlines directly touching an image URL it inlines

Both reproduce with `from:npub19xgymswuxyq4sx58enft9c6algrm72a6lchplm4rjzgklufn9ygq5kcu58` (image gap visible on posts 2-8).

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (added regression coverage: `inlineImage.test.ts` for newline stripping around inlined images, and a `NoteListItem.test.ts` case pinning the name span's shrinkable/truncate classes)
- [x] Verified in a real browser at 375px viewport width against the reproduction query that the long name now truncates without overlapping the menu button, and that images no longer have the extra top gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)