### PR TITLE
fix(page): remove debug logging

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -52,9 +52,6 @@
     // or submitted through it, not the query actually shown on screen.
     query = data.q ?? '';
   });
-  $effect(() => {
-    console.debug('data', data);
-  });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary

- Remove the development-only debug logging effect from the search page.

## Testing

- `npm test`
- `npm run build`