### PR TITLE
refactor(nostr): centralize identifier shortening

### DIFF
--- a/src/lib/actions/linkify.ts
+++ b/src/lib/actions/linkify.ts
@@ -2,6 +2,7 @@ import linkifyHtml from 'linkify-html';
 import 'linkify-plugin-mention';
 // import type { Action } from 'svelte/runtime/action/public';
 import type { Opts } from 'linkifyjs';
+import { shortenNostrId } from '$lib/nostr';
 
 export const linkifyOpts = {
   className: 'underline',
@@ -9,7 +10,7 @@ export const linkifyOpts = {
   rel: 'external noreferrer',
   format: (value: string, type: string) => {
     if (type === 'mention') {
-      return `${value.substring(0, 9)}:${value.substring(value.length - 8, value.length)}`;
+      return shortenNostrId(value);
     }
 
     return value;

--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -4,6 +4,7 @@
   import { zostr } from 'zod-nostr';
   import { inlineImage } from '$lib/actions/inlineImage';
   import { linkify, linkifyOpts } from '$lib/actions/linkify';
+  import { shortenNostrId } from '$lib/nostr';
   import { NostrProfileContentSchema, type NostrProfileMetadata } from '$lib/profile';
   import Nip05Badge from './Nip05Badge.svelte';
   import NoteListItemMenu from './NoteListItemMenu.svelte';
@@ -30,7 +31,6 @@
   // box with a "Show more" trigger that reveals nothing new.
   const IMAGE_URL_PATTERN = /https?:\/\/\S+\.(?:jpe?g|png|gif|webp)\b/i;
 
-  const shorten = (id: string) => `${id.substring(0, 9)}:${id.substring(id.length - 8, id.length)}`;
   const parseProfileMetadata = (content: string): NostrProfileMetadata | undefined => {
     const parsed = NostrProfileContentSchema.safeParse(content);
     return parsed.success ? parsed.data : undefined;
@@ -38,7 +38,7 @@
 
   let profileMetadata = $derived(profile ? parseProfileMetadata(profile.content) : undefined);
   let nameOrPubkey = $derived(
-    profileMetadata?.name || profileMetadata?.display_name || shorten(note.pubkey)
+    profileMetadata?.name || profileMetadata?.display_name || shortenNostrId(note.pubkey)
   );
 
   const transformContent = (content: string | undefined) =>

--- a/src/lib/nostr.test.ts
+++ b/src/lib/nostr.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { shortenNostrId } from './nostr';
+
+describe('shortenNostrId', () => {
+  it('keeps the first nine and last eight characters', () => {
+    expect(shortenNostrId('a'.repeat(64))).toBe('aaaaaaaaa:aaaaaaaa');
+  });
+
+  it('preserves a mention prefix as part of the shortened identifier', () => {
+    expect(shortenNostrId(`@npub1${'a'.repeat(58)}`)).toBe('@npub1aaa:aaaaaaaa');
+  });
+});

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -1,0 +1,5 @@
+const PREFIX_LENGTH = 9;
+const SUFFIX_LENGTH = 8;
+
+export const shortenNostrId = (id: string) =>
+  `${id.slice(0, PREFIX_LENGTH)}:${id.slice(-SUFFIX_LENGTH)}`;


### PR DESCRIPTION
## Summary

- Add a shared helper for shortening Nostr identifiers.
- Use the helper for linkified mentions and note author fallbacks.
- Cover both pubkeys and `@npub` mentions with unit tests.

## Testing

- `npm test`
- `npm run build`