### PR TITLE
refactor(search): co-locate advanced form schema

### DIFF
--- a/src/lib/components/AdvancedSearchModal.form.test.ts
+++ b/src/lib/components/AdvancedSearchModal.form.test.ts
@@ -1,6 +1,6 @@
 import { nip19 } from 'nostr-tools';
 import { describe, expect, it } from 'vitest';
-import { AdvancedSearchFormSchema } from './advanced-form';
+import { AdvancedSearchFormSchema } from './AdvancedSearchModal.form';
 
 const mattnNpub = 'npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6';
 

--- a/src/lib/components/AdvancedSearchModal.form.ts
+++ b/src/lib/components/AdvancedSearchModal.form.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { zostr } from 'zod-nostr';
-import { isoDateCodec, SearchFiltersSchema } from './filters';
+import { isoDateCodec, SearchFiltersSchema } from '../search/filters';
 
 const emptyString = z.literal('');
 const npubCodec = zostr.npub();

--- a/src/lib/components/AdvancedSearchModal.svelte
+++ b/src/lib/components/AdvancedSearchModal.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import { autocomplete } from '$lib/actions/autocomplete.svelte';
-  import {
-    type AdvancedSearchFormData,
-    AdvancedSearchFormSchema,
-  } from '$lib/search/advanced-form';
   import type { SearchFilters } from '$lib/search/filters';
+  import { type AdvancedSearchFormData, AdvancedSearchFormSchema } from './AdvancedSearchModal.form';
 
   interface Props {
     onClose: () => void;


### PR DESCRIPTION
## Summary

- Co-locate the advanced-search form schema with `AdvancedSearchModal`.
- Keep the search domain focused on reusable filters rather than one component's form state.

## Testing

- `npm test`
- `npm run build`