### PR TITLE
refactor(seo): extract search page metadata

### DIFF
--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { createSearchPageSeo } from './seo';
+
+describe('createSearchPageSeo', () => {
+  it('uses the site root for the initial page', () => {
+    expect(createSearchPageSeo('', 0)).toEqual({
+      isInitial: true,
+      url: 'https://nosey.vercel.app',
+    });
+  });
+
+  it('creates a canonical URL for a search query', () => {
+    expect(createSearchPageSeo('from:npub1abc', 0)).toEqual({
+      isInitial: false,
+      url: 'https://nosey.vercel.app/?q=from%3Anpub1abc',
+    });
+  });
+
+  it('includes a non-initial result page', () => {
+    expect(createSearchPageSeo('hello', 2)).toEqual({
+      isInitial: false,
+      url: 'https://nosey.vercel.app/?q=hello&page=2',
+    });
+  });
+});

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,15 @@
+const SITE_URL = 'https://nosey.vercel.app';
+
+export const createSearchPageSeo = (query: string, page: number) => {
+  const isInitial = query === '';
+  if (isInitial) {
+    return { isInitial, url: SITE_URL };
+  }
+
+  const params = new URLSearchParams({ q: query });
+  if (page !== 0) {
+    params.set('page', page.toString());
+  }
+
+  return { isInitial, url: `${SITE_URL}/?${params}` };
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
   import Alert from '$lib/components/Alert.svelte';
   import JsonLd from '$lib/components/JsonLd.svelte';
   import NoteList from '$lib/components/NoteList.svelte';
+  import { createSearchPageSeo } from '$lib/seo';
   import type { PageData } from '$lib/types';
 
   interface Props {
@@ -41,10 +42,7 @@
   };
 
   let q = $derived(data.q ?? '');
-  let page = $derived(data.page === 0 ? undefined : data.page);
-  let params = $derived(page ? new URLSearchParams({ q, page: page.toString() }) : new URLSearchParams({ q }));
-  let isInitial = $derived(q === '');
-  let url = $derived(`https://nosey.vercel.app${isInitial ? '' : `/${params}`}`);
+  let seo = $derived(createSearchPageSeo(q, data.page));
   $effect(() => {
     // Resync the input's local edit buffer whenever the URL's `q` changes from
     // somewhere other than this form (a link, pagination, browser back/forward).
@@ -55,31 +53,31 @@
 </script>
 
 <svelte:head>
-  {#if isInitial}
+  {#if seo.isInitial}
     <title>nosey | A Nostr searcher</title>
   {:else}
     <title>{q} - nosey</title>
   {/if}
   <meta name="description" content="A Nostr searcher" />
   <meta name="keywords" content="nostr,search,notes,damus,snort" />
-  <meta property="og:url" content={url} />
-  <meta property="og:title" content={isInitial ? 'nosey' : `{q} - nosey`} />
+  <meta property="og:url" content={seo.url} />
+  <meta property="og:title" content={seo.isInitial ? 'nosey' : `${q} - nosey`} />
   <meta property="og:description" content="A Nostr searcher" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="nosey" />
   <meta property="og:image" content="https://nosey.vercel.app/ogp.png" />
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:image" content="https://nosey.vercel.app/favicon.png" />
-  <link rel="canonical" href={url} />
-  <JsonLd {url} isRoot={isInitial} />
+  <link rel="canonical" href={seo.url} />
+  <JsonLd url={seo.url} isRoot={seo.isInitial} />
 </svelte:head>
 
 <form
   onsubmit={handleSearch}
   class="flex flex-col gap-6 justify-center items-center"
-  class:flex-1={isInitial}
+  class:flex-1={seo.isInitial}
 >
-  {#if isInitial}
+  {#if seo.isInitial}
     <h1 class="h1">nosey</h1>
     <p>A nostr searcher</p>
   {/if}
@@ -102,7 +100,7 @@
     </div>
   </div>
 
-  {#if isInitial}
+  {#if seo.isInitial}
     <Alert>
       <div class="flex gap-1">
         <p><b>Tips:</b></p>


### PR DESCRIPTION
## Summary

- Extract search-page SEO metadata generation into a tested helper.
- Correct canonical search URLs to use query parameters.
- Keep the route component focused on search interactions and rendering.

## Testing

- `npm test`
- `npm run build`