### PR TITLE
refactor(profile): share display name resolution

### DIFF
--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -5,7 +5,11 @@
   import { inlineImage } from '$lib/actions/inlineImage';
   import { linkify, linkifyOpts } from '$lib/actions/linkify';
   import { shortenNostrId } from '$lib/nostr';
-  import { NostrProfileContentSchema, type NostrProfileMetadata } from '$lib/profile';
+  import {
+    NostrProfileContentSchema,
+    type NostrProfileMetadata,
+    resolveProfileDisplayName,
+  } from '$lib/profile';
   import Nip05Badge from './Nip05Badge.svelte';
   import NoteListItemMenu from './NoteListItemMenu.svelte';
   import ProfileAvatar from './ProfileAvatar.svelte';
@@ -38,7 +42,9 @@
 
   let profileMetadata = $derived(profile ? parseProfileMetadata(profile.content) : undefined);
   let nameOrPubkey = $derived(
-    profileMetadata?.name || profileMetadata?.display_name || shortenNostrId(note.pubkey)
+    profileMetadata
+      ? resolveProfileDisplayName(profileMetadata, shortenNostrId(note.pubkey))
+      : shortenNostrId(note.pubkey)
   );
 
   const transformContent = (content: string | undefined) =>

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { zostr } from 'zod-nostr';
-import { NostrProfileContentSchema } from './profile';
+import { NostrProfileContentSchema, resolveProfileDisplayName } from './profile';
 
 describe('Nostr profile metadata', () => {
   it('uses zod-nostr to validate and format NIP-05 identifiers', () => {
@@ -25,5 +25,25 @@ describe('Nostr profile metadata', () => {
 
   it.each(['not json', 'null', '[]'])('rejects invalid profile content: %s', (content) => {
     expect(NostrProfileContentSchema.safeParse(content).success).toBe(false);
+  });
+
+  it('resolves a display name by name, display name, then fallback', () => {
+    expect(
+      resolveProfileDisplayName(
+        NostrProfileContentSchema.parse(
+          JSON.stringify({ name: 'Alice', display_name: 'Different' })
+        ),
+        'fallback'
+      )
+    ).toBe('Alice');
+    expect(
+      resolveProfileDisplayName(
+        NostrProfileContentSchema.parse(JSON.stringify({ display_name: 'Alice' })),
+        'fallback'
+      )
+    ).toBe('Alice');
+    expect(resolveProfileDisplayName(NostrProfileContentSchema.parse('{}'), 'fallback')).toBe(
+      'fallback'
+    );
   });
 });

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -12,6 +12,9 @@ export const NostrProfileMetadataSchema = z.object({
 
 export type NostrProfileMetadata = z.output<typeof NostrProfileMetadataSchema>;
 
+export const resolveProfileDisplayName = (metadata: NostrProfileMetadata, fallback: string) =>
+  metadata.name || metadata.display_name || fallback;
+
 // zostr.nip01.metadata() is intentionally strict. Search results may contain
 // partial profile metadata, so retain this UI-specific fallback behavior here.
 export const NostrProfileContentSchema = z

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { zostr } from 'zod-nostr';
-import { NostrProfileContentSchema, NostrProfileMetadataSchema } from '$lib/profile';
+import {
+  NostrProfileContentSchema,
+  NostrProfileMetadataSchema,
+  resolveProfileDisplayName,
+} from '$lib/profile';
 import type { SearchResult } from '$lib/search/result';
 
 export type { SearchResult, SearchResultPagination } from '$lib/search/result';
@@ -31,7 +35,7 @@ export const MentionItemSchema = z
     return {
       pubkey,
       content,
-      name: profile.name || profile.display_name || pubkey,
+      name: resolveProfileDisplayName(profile, pubkey),
       picture: profile.picture,
       nip05: zostr.nip05.formatIdentifier(profile.nip05),
     };


### PR DESCRIPTION
## Summary

- Centralize profile display-name resolution.
- Preserve each caller's fallback representation while sharing the name → display name → fallback priority.

## Testing

- `npm test`
- `npm run build`