### PR TITLE
refactor(mention): extract suggestion item schema

### DIFF
--- a/src/lib/actions/autocomplete.svelte.ts
+++ b/src/lib/actions/autocomplete.svelte.ts
@@ -2,8 +2,8 @@ import { nip19 } from 'nostr-tools';
 import { mount, unmount } from 'svelte';
 import { browser } from '$app/environment';
 import MentionMenu from '$lib/components/MentionMenu.svelte';
+import type { MentionItem } from '$lib/mention';
 import { profileSuggestions } from '$lib/stores/profileSuggestions';
-import type { MentionItem } from '$lib/types';
 
 // This intentionally hand-rolls keyboard navigation instead of using
 // @skeletonlabs/skeleton-svelte's `Menu` or `Combobox` (both wrap @zag-js

--- a/src/lib/actions/autocomplete.test.ts
+++ b/src/lib/actions/autocomplete.test.ts
@@ -2,8 +2,8 @@ import { fireEvent, render } from '@testing-library/svelte';
 import { nip19 } from 'nostr-tools';
 import { writable } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MentionItem } from '$lib/mention';
 import type { ProfileSuggestions, ProfileSuggestionsState } from '$lib/stores/profileSuggestions';
-import type { MentionItem } from '$lib/types';
 
 const { profileSuggestionsMock } = vi.hoisted(() => ({ profileSuggestionsMock: vi.fn() }));
 

--- a/src/lib/components/MentionMenu.svelte
+++ b/src/lib/components/MentionMenu.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { usePopover } from '@skeletonlabs/skeleton-svelte';
-  import type { MentionItem } from '$lib/types';
+  import type { MentionItem } from '$lib/mention';
   import Nip05Badge from './Nip05Badge.svelte';
   import ProfileAvatar from './ProfileAvatar.svelte';
 

--- a/src/lib/components/MentionMenu.test.ts
+++ b/src/lib/components/MentionMenu.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
-import type { MentionItem } from '$lib/types';
+import type { MentionItem } from '$lib/mention';
 import MentionMenu from './MentionMenu.svelte';
 
 // Nip05Badge fetches over the network to verify NIP-05 identifiers; stub out

--- a/src/lib/mention.test.ts
+++ b/src/lib/mention.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { MentionItemSchema } from './types';
+import { MentionItemSchema } from './mention';
 
 const pubkey = 'a'.repeat(64);
 

--- a/src/lib/mention.ts
+++ b/src/lib/mention.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { zostr } from 'zod-nostr';
+import {
+  NostrProfileContentSchema,
+  NostrProfileMetadataSchema,
+  resolveProfileDisplayName,
+} from './profile';
+
+const NostrProfileContentWithFallbackSchema = NostrProfileContentSchema.catch(
+  NostrProfileMetadataSchema.parse({})
+);
+
+export const MentionItemSchema = z
+  .object({
+    pubkey: zostr.pubkey(),
+    content: z.string(),
+  })
+  .transform(({ pubkey, content }) => {
+    const profile = NostrProfileContentWithFallbackSchema.parse(content);
+
+    return {
+      pubkey,
+      content,
+      name: resolveProfileDisplayName(profile, pubkey),
+      picture: profile.picture,
+      nip05: zostr.nip05.formatIdentifier(profile.nip05),
+    };
+  });
+
+export type MentionItem = z.output<typeof MentionItemSchema>;

--- a/src/lib/stores/profileSuggestions.ts
+++ b/src/lib/stores/profileSuggestions.ts
@@ -13,10 +13,10 @@ import {
 } from 'rxjs';
 import { type Readable, writable } from 'svelte/store';
 import { HttpTooManyRequestsError } from '$lib/errors';
+import { type MentionItem, MentionItemSchema } from '$lib/mention';
 import { rateLimitedSearch } from '$lib/search/rate-limited';
 import { createProfileSuggestionRequest } from '$lib/search/request';
 import type { SearchResult } from '$lib/search/result';
-import { type MentionItem, MentionItemSchema } from '$lib/types';
 
 const MENU_ITEM_LIMIT = 10;
 const SEARCH_DEBOUNCE_MS = 250;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,10 +1,3 @@
-import { z } from 'zod';
-import { zostr } from 'zod-nostr';
-import {
-  NostrProfileContentSchema,
-  NostrProfileMetadataSchema,
-  resolveProfileDisplayName,
-} from '$lib/profile';
 import type { SearchResult } from '$lib/search/result';
 
 export type { SearchResult, SearchResultPagination } from '$lib/search/result';
@@ -19,26 +12,3 @@ export type Profile = Partial<{
   display_name: string;
   name: string;
 }>;
-
-const NostrProfileContentWithFallbackSchema = NostrProfileContentSchema.catch(
-  NostrProfileMetadataSchema.parse({})
-);
-
-export const MentionItemSchema = z
-  .object({
-    pubkey: zostr.pubkey(),
-    content: z.string(),
-  })
-  .transform(({ pubkey, content }) => {
-    const profile = NostrProfileContentWithFallbackSchema.parse(content);
-
-    return {
-      pubkey,
-      content,
-      name: resolveProfileDisplayName(profile, pubkey),
-      picture: profile.picture,
-      nip05: zostr.nip05.formatIdentifier(profile.nip05),
-    };
-  });
-
-export type MentionItem = z.output<typeof MentionItemSchema>;


### PR DESCRIPTION
## Summary

- Move mention suggestion normalization out of the generic types module.
- Keep the mention display model and its schema together in `src/lib/mention.ts`.
- Reuse the shared profile display-name resolver.

## Testing

- `npm test`
- `npm run build`