### PR TITLE
refactor(types): remove unused profile type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,8 +7,3 @@ export type PageData = {
   page: number;
   result: SearchResult;
 };
-
-export type Profile = Partial<{
-  display_name: string;
-  name: string;
-}>;


### PR DESCRIPTION
## Summary

- Remove the unused `Profile` type from `src/lib/types.ts`.
- Keep profile metadata and display-name concerns centralized in `src/lib/profile.ts`.

## Testing

- `npm run lint`
- `npm run check`
- `npm test`
- `npm run build`
