### PR TITLE
refactor(profile): unify profile resolution into IdentifiedProfile

### DIFF
--- a/src/lib/actions/autocomplete.test.ts
+++ b/src/lib/actions/autocomplete.test.ts
@@ -15,10 +15,7 @@ import AutocompleteTestHost from './AutocompleteTestHost.svelte';
 
 const makeItem = (pubkey: string, name: string): MentionItem => ({
   pubkey,
-  content: JSON.stringify({ name }),
-  name,
-  picture: '',
-  nip05: '',
+  profile: { name, display_name: '', picture: '', nip05: '' },
 });
 
 const createSuggestions = () => {

--- a/src/lib/components/MentionMenu.svelte
+++ b/src/lib/components/MentionMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { usePopover } from '@skeletonlabs/skeleton-svelte';
   import type { MentionItem } from '$lib/mention';
+  import { resolveDisplayName, resolveNip05Display } from '$lib/profile';
   import Nip05Badge from './Nip05Badge.svelte';
   import ProfileAvatar from './ProfileAvatar.svelte';
 
@@ -94,12 +95,16 @@
               onmousedown={(e) => e.preventDefault()}
               onclick={() => onSelect(item)}
             >
-              <ProfileAvatar picture={item.picture} name={item.name} class="w-6 h-6 shrink-0" />
-              <span class="min-w-0 truncate">{item.name}</span>
-              {#if item.nip05}
+              <ProfileAvatar
+                picture={item.profile.picture}
+                name={resolveDisplayName(item)}
+                class="w-6 h-6 shrink-0"
+              />
+              <span class="min-w-0 truncate">{resolveDisplayName(item)}</span>
+              {#if item.profile.nip05}
                 <span class="min-w-0 shrink-[999] truncate flex items-center gap-1">
-                  <code class="code truncate">{item.nip05}</code>
-                  <Nip05Badge pubkey={item.pubkey} nip05={item.nip05} />
+                  <code class="code truncate">{resolveNip05Display(item)}</code>
+                  <Nip05Badge pubkey={item.pubkey} nip05={resolveNip05Display(item)} />
                 </span>
               {/if}
             </button>

--- a/src/lib/components/MentionMenu.test.ts
+++ b/src/lib/components/MentionMenu.test.ts
@@ -11,13 +11,16 @@ vi.mock('$lib/nip05', async (importOriginal) => ({
   verifyNip05: vi.fn(() => new Promise(() => {})),
 }));
 
-const makeItem = (overrides: Partial<MentionItem> = {}): MentionItem => ({
-  pubkey: 'pubkey1',
-  content: '{}',
-  name: 'Alice',
-  picture: '',
-  nip05: '',
-  ...overrides,
+const makeItem = (
+  overrides: Partial<{ pubkey: string; name: string; picture: string; nip05: string }> = {}
+): MentionItem => ({
+  pubkey: overrides.pubkey ?? 'pubkey1',
+  profile: {
+    name: overrides.name ?? 'Alice',
+    display_name: '',
+    picture: overrides.picture ?? '',
+    nip05: overrides.nip05 ?? '',
+  },
 });
 
 const baseProps = {

--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
   import { Collapsible } from '@skeletonlabs/skeleton-svelte';
   import type * as Nostr from 'nostr-typedef';
-  import { zostr } from 'zod-nostr';
   import { inlineImage } from '$lib/actions/inlineImage';
   import { linkify, linkifyOpts } from '$lib/actions/linkify';
-  import { shortenNostrId } from '$lib/nostr';
   import { hasInlineImageUrl, isNoteContentDefinitelyLong, transformNoteContent } from '$lib/note';
-  import { parseNostrProfileContent, resolveProfileDisplayName } from '$lib/profile';
+  import { resolveDisplayName, resolveIdentifiedProfile, resolveNip05Display } from '$lib/profile';
   import Nip05Badge from './Nip05Badge.svelte';
   import NoteListItemMenu from './NoteListItemMenu.svelte';
   import ProfileAvatar from './ProfileAvatar.svelte';
@@ -20,12 +18,8 @@
 
   // Roughly the height of 8 lines of body text (the old line-clamp-8 behavior).
   const COLLAPSED_HEIGHT = 192;
-  let profileMetadata = $derived(profile ? parseNostrProfileContent(profile.content) : undefined);
-  let nameOrPubkey = $derived(
-    profileMetadata
-      ? resolveProfileDisplayName(profileMetadata, shortenNostrId(note.pubkey))
-      : shortenNostrId(note.pubkey)
-  );
+  let identified = $derived(resolveIdentifiedProfile(note.pubkey, profile?.content));
+  let nameOrPubkey = $derived(resolveDisplayName(identified));
 
   let noteContent = $derived(transformNoteContent(note.content));
   let isDefinitelyLong = $derived(isNoteContentDefinitelyLong(note.content));
@@ -89,15 +83,15 @@
   <div class="p-4">
     <div class="flex justify-between items-center">
       <div class="mr-2 flex-none">
-        <ProfileAvatar picture={profileMetadata?.picture ?? ''} name={nameOrPubkey} />
+        <ProfileAvatar picture={identified.profile.picture} name={nameOrPubkey} />
       </div>
 
       <p class="flex-auto min-w-0 flex items-center gap-1">
         <span class="font-bold truncate min-w-0">{nameOrPubkey}</span>
-        {#if profileMetadata?.nip05}
+        {#if identified.profile.nip05}
           <span class="min-w-0 flex-1 truncate flex items-center gap-1">
-            <code class="code truncate overflow-x-hidden!">{zostr.nip05.formatIdentifier(profileMetadata.nip05)}</code>
-            <Nip05Badge pubkey={note.pubkey} nip05={profileMetadata.nip05} />
+            <code class="code truncate overflow-x-hidden!">{resolveNip05Display(identified)}</code>
+            <Nip05Badge pubkey={note.pubkey} nip05={resolveNip05Display(identified)} />
           </span>
         {/if}
       </p>

--- a/src/lib/components/NoteListItem.test.ts
+++ b/src/lib/components/NoteListItem.test.ts
@@ -102,7 +102,7 @@ describe('NoteListItem', () => {
     });
 
     expect(container.querySelector('code')?.textContent).toBe('example.com');
-    expect(mockedVerifyNip05).toHaveBeenCalledExactlyOnceWith(note.pubkey, '_@example.com');
+    expect(mockedVerifyNip05).toHaveBeenCalledExactlyOnceWith(note.pubkey, 'example.com');
   });
 
   it('does not show a nip05 identifier or verify when absent from the profile', () => {

--- a/src/lib/mention.test.ts
+++ b/src/lib/mention.test.ts
@@ -4,7 +4,7 @@ import { MentionItemSchema } from './mention';
 const pubkey = 'a'.repeat(64);
 
 describe('MentionItemSchema', () => {
-  it('normalizes profile metadata for display', () => {
+  it('resolves profile metadata into an IdentifiedProfile', () => {
     expect(
       MentionItemSchema.parse({
         pubkey,
@@ -17,25 +17,19 @@ describe('MentionItemSchema', () => {
       })
     ).toEqual({
       pubkey,
-      content: JSON.stringify({
-        name: ' Alice ',
+      profile: {
+        name: 'Alice',
         display_name: 'Different name',
         picture: 'https://example.com/alice.png',
         nip05: '_@example.com',
-      }),
-      name: 'Alice',
-      picture: 'https://example.com/alice.png',
-      nip05: 'example.com',
+      },
     });
   });
 
-  it('falls back to safe display values for malformed profile content', () => {
+  it('falls back to an empty profile for malformed profile content', () => {
     expect(MentionItemSchema.parse({ pubkey, content: '{not valid json' })).toEqual({
       pubkey,
-      content: '{not valid json',
-      name: pubkey,
-      picture: '',
-      nip05: '',
+      profile: { name: '', display_name: '', picture: '', nip05: '' },
     });
   });
 
@@ -47,10 +41,7 @@ describe('MentionItemSchema', () => {
       })
     ).toEqual({
       pubkey,
-      content: JSON.stringify({ name: 42, display_name: ' Alice ', picture: {}, nip05: 'bad' }),
-      name: 'Alice',
-      picture: '',
-      nip05: '',
+      profile: { name: '', display_name: 'Alice', picture: '', nip05: '' },
     });
   });
 });

--- a/src/lib/mention.ts
+++ b/src/lib/mention.ts
@@ -1,30 +1,12 @@
 import { z } from 'zod';
 import { zostr } from 'zod-nostr';
-import {
-  NostrProfileContentSchema,
-  NostrProfileMetadataSchema,
-  resolveProfileDisplayName,
-} from './profile';
-
-const NostrProfileContentWithFallbackSchema = NostrProfileContentSchema.catch(
-  NostrProfileMetadataSchema.parse({})
-);
+import { resolveIdentifiedProfile } from './profile';
 
 export const MentionItemSchema = z
   .object({
     pubkey: zostr.pubkey(),
     content: z.string(),
   })
-  .transform(({ pubkey, content }) => {
-    const profile = NostrProfileContentWithFallbackSchema.parse(content);
-
-    return {
-      pubkey,
-      content,
-      name: resolveProfileDisplayName(profile, pubkey),
-      picture: profile.picture,
-      nip05: zostr.nip05.formatIdentifier(profile.nip05),
-    };
-  });
+  .transform(({ pubkey, content }) => resolveIdentifiedProfile(pubkey, content));
 
 export type MentionItem = z.output<typeof MentionItemSchema>;

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { zostr } from 'zod-nostr';
 import {
-  NostrProfileContentSchema,
-  parseNostrProfileContent,
-  resolveProfileDisplayName,
+  ProfileContentSchema,
+  resolveDisplayName,
+  resolveIdentifiedProfile,
+  resolveNip05Display,
 } from './profile';
+
+const pubkey = 'a'.repeat(64);
 
 describe('Nostr profile metadata', () => {
   it('uses zod-nostr to validate and format NIP-05 identifiers', () => {
@@ -15,7 +18,7 @@ describe('Nostr profile metadata', () => {
 
   it('drops malformed profile properties while retaining valid ones', () => {
     expect(
-      NostrProfileContentSchema.parse(
+      ProfileContentSchema.parse(
         JSON.stringify({
           name: 42,
           display_name: ' Alice ',
@@ -28,33 +31,60 @@ describe('Nostr profile metadata', () => {
   });
 
   it.each(['not json', 'null', '[]'])('rejects invalid profile content: %s', (content) => {
-    expect(NostrProfileContentSchema.safeParse(content).success).toBe(false);
+    expect(ProfileContentSchema.safeParse(content).success).toBe(false);
+  });
+});
+
+describe('resolveIdentifiedProfile', () => {
+  it('resolves valid profile content', () => {
+    expect(
+      resolveIdentifiedProfile(pubkey, JSON.stringify({ name: 'Alice' })).profile
+    ).toMatchObject({ name: 'Alice' });
   });
 
-  it('resolves a display name by name, display name, then fallback', () => {
-    expect(
-      resolveProfileDisplayName(
-        NostrProfileContentSchema.parse(
-          JSON.stringify({ name: 'Alice', display_name: 'Different' })
-        ),
-        'fallback'
-      )
-    ).toBe('Alice');
-    expect(
-      resolveProfileDisplayName(
-        NostrProfileContentSchema.parse(JSON.stringify({ display_name: 'Alice' })),
-        'fallback'
-      )
-    ).toBe('Alice');
-    expect(resolveProfileDisplayName(NostrProfileContentSchema.parse('{}'), 'fallback')).toBe(
-      'fallback'
-    );
-  });
-
-  it('returns undefined for invalid profile content', () => {
-    expect(parseNostrProfileContent('not json')).toBeUndefined();
-    expect(parseNostrProfileContent(JSON.stringify({ name: 'Alice' }))).toMatchObject({
-      name: 'Alice',
+  it('falls back to an empty profile for missing or invalid content', () => {
+    expect(resolveIdentifiedProfile(pubkey).profile).toEqual({
+      name: '',
+      display_name: '',
+      picture: '',
+      nip05: '',
     });
+    expect(resolveIdentifiedProfile(pubkey, 'not json').profile).toEqual({
+      name: '',
+      display_name: '',
+      picture: '',
+      nip05: '',
+    });
+  });
+});
+
+describe('resolveDisplayName', () => {
+  it('resolves a display name by name, display name, then a shortened pubkey', () => {
+    expect(
+      resolveDisplayName(
+        resolveIdentifiedProfile(
+          pubkey,
+          JSON.stringify({ name: 'Alice', display_name: 'Different' })
+        )
+      )
+    ).toBe('Alice');
+    expect(
+      resolveDisplayName(
+        resolveIdentifiedProfile(pubkey, JSON.stringify({ display_name: 'Alice' }))
+      )
+    ).toBe('Alice');
+    expect(resolveDisplayName(resolveIdentifiedProfile(pubkey, '{}'))).toBe('aaaaaaaaa:aaaaaaaa');
+  });
+});
+
+describe('resolveNip05Display', () => {
+  it('formats the identifier for display', () => {
+    expect(
+      resolveNip05Display(resolveIdentifiedProfile(pubkey, JSON.stringify({ nip05: '_@bob.com' })))
+    ).toBe('bob.com');
+  });
+
+  it('returns an empty string when there is no identifier', () => {
+    expect(resolveNip05Display(resolveIdentifiedProfile(pubkey, '{}'))).toBe('');
   });
 });

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,23 +1,27 @@
 import { z } from 'zod';
 import { zostr } from 'zod-nostr';
+import { shortenNostrId } from './nostr';
 
 const ProfileMetadataStringSchema = z.string().trim().min(1).catch('');
 
-export const NostrProfileMetadataSchema = z.object({
+export const ProfileSchema = z.object({
   name: ProfileMetadataStringSchema,
   display_name: ProfileMetadataStringSchema,
   picture: ProfileMetadataStringSchema,
   nip05: zostr.nip05.identifier().catch(''),
 });
 
-export type NostrProfileMetadata = z.output<typeof NostrProfileMetadataSchema>;
+export type Profile = z.output<typeof ProfileSchema>;
 
-export const resolveProfileDisplayName = (metadata: NostrProfileMetadata, fallback: string) =>
-  metadata.name || metadata.display_name || fallback;
+// A profile tied to the pubkey it was fetched for, so display helpers can
+// fall back to something derived from the pubkey without callers having to
+// compute and pass that fallback themselves.
+export type IdentifiedProfile = { pubkey: string; profile: Profile };
 
-// zostr.nip01.metadata() is intentionally strict. Search results may contain
-// partial profile metadata, so retain this UI-specific fallback behavior here.
-export const NostrProfileContentSchema = z
+// zostr.nip01.metadata() is intentionally strict. Search results and note
+// authors may carry partial or malformed profile metadata, so retain this
+// UI-specific fallback behavior here.
+export const ProfileContentSchema = z
   .string()
   .transform((content, ctx) => {
     try {
@@ -27,9 +31,20 @@ export const NostrProfileContentSchema = z
       return z.NEVER;
     }
   })
-  .pipe(NostrProfileMetadataSchema);
+  .pipe(ProfileSchema);
 
-export const parseNostrProfileContent = (content: string): NostrProfileMetadata | undefined => {
-  const parsed = NostrProfileContentSchema.safeParse(content);
-  return parsed.success ? parsed.data : undefined;
-};
+const emptyProfile = ProfileSchema.parse({});
+const ProfileContentWithFallbackSchema = ProfileContentSchema.catch(emptyProfile);
+
+// Always returns a usable IdentifiedProfile, even when `content` is missing,
+// unparseable, or only partially valid.
+export const resolveIdentifiedProfile = (pubkey: string, content?: string): IdentifiedProfile => ({
+  pubkey,
+  profile: content ? ProfileContentWithFallbackSchema.parse(content) : emptyProfile,
+});
+
+export const resolveDisplayName = ({ pubkey, profile }: IdentifiedProfile): string =>
+  profile.name || profile.display_name || shortenNostrId(pubkey);
+
+export const resolveNip05Display = ({ profile }: IdentifiedProfile): string =>
+  zostr.nip05.formatIdentifier(profile.nip05);

--- a/src/lib/stores/profileSuggestions.test.ts
+++ b/src/lib/stores/profileSuggestions.test.ts
@@ -54,7 +54,7 @@ describe('profileSuggestions', () => {
     expect(search).toHaveBeenCalledWith('alice', expect.any(AbortSignal));
     expect(latest).toEqual({
       loading: false,
-      items: [expect.objectContaining({ name: 'Alice' })],
+      items: [expect.objectContaining({ profile: expect.objectContaining({ name: 'Alice' }) })],
       error: null,
     });
 
@@ -156,21 +156,23 @@ describe('profileSuggestions', () => {
     suggestions.destroy();
   });
 
-  it('falls back to the pubkey for malformed profile JSON', async () => {
+  it('falls back to a shortened pubkey for malformed profile JSON', async () => {
     vi.useFakeTimers();
     const pubkey = 'd'.repeat(64);
     const suggestions = profileSuggestions({
       search: vi.fn().mockResolvedValue(result('{not valid json', pubkey)),
     });
-    let latestName = '';
+    let latest: ProfileSuggestionsState = { loading: false, items: [], error: null };
     const unsubscribe = suggestions.subscribe((state) => {
-      latestName = state.items[0]?.name ?? '';
+      latest = state;
     });
 
     suggestions.search('alice');
     await vi.advanceTimersByTimeAsync(250);
 
-    expect(latestName).toBe(pubkey);
+    expect(latest.items).toEqual([
+      { pubkey, profile: { name: '', display_name: '', picture: '', nip05: '' } },
+    ]);
     unsubscribe();
     suggestions.destroy();
   });
@@ -198,7 +200,14 @@ describe('profileSuggestions', () => {
     await vi.advanceTimersByTimeAsync(250);
 
     expect(latest.items).toEqual([
-      expect.objectContaining({ name: 'Alice', picture: '', nip05: 'bob.com' }),
+      expect.objectContaining({
+        profile: expect.objectContaining({
+          name: '',
+          display_name: 'Alice',
+          picture: '',
+          nip05: '_@bob.com',
+        }),
+      }),
     ]);
     unsubscribe();
     suggestions.destroy();


### PR DESCRIPTION
## Summary
- `MentionItem` carried the raw search-API `content` string even though only `pubkey`/`name`/`picture`/`nip05` were ever consumed by `MentionMenu.svelte` and `autocomplete.svelte.ts`, and duplicated the "always resolve a safe profile from missing/malformed content" logic that also lived in `NoteListItem.svelte`'s caller-side fallback.
- Introduces `IdentifiedProfile` (`{ pubkey, profile }`) plus `resolveIdentifiedProfile` / `resolveDisplayName` / `resolveNip05Display` in `profile.ts` as the single source of this behavior. `MentionItem` is now an `IdentifiedProfile` directly, and the old `NostrProfileMetadata`/`resolveProfileDisplayName`/`parseNostrProfileContent` API and mention.ts's local fallback schema are removed.
- Two consumer-visible behaviors are now consistent instead of diverging:
  - The display-name fallback always shortens the pubkey (`MentionMenu` previously showed the full 64-char pubkey when a profile failed to resolve).
  - NIP-05 formatting happens once via `resolveNip05Display` at render time in both components, instead of being pre-baked into `mention.ts`'s transform for one and done ad hoc in `NoteListItem.svelte` for the other.

## Test plan
- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npm run lint` (biome, 0 errors)
- [x] `npm test` (119 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)