### PR TITLE
refactor(seo): move page title and OGP metadata into createSearchPageSeo

### DIFF
--- a/src/lib/components/JsonLd.svelte
+++ b/src/lib/components/JsonLd.svelte
@@ -2,20 +2,10 @@
   import { jsonLdTag } from '$lib/helpers/jsonLdTag';
 
   interface Props {
-    url: string;
-    isRoot: boolean;
+    jsonLd: object;
   }
 
-  let { url, isRoot }: Props = $props();
-
-  let jsonLd = $derived({
-    '@context': 'https://schema.org',
-    '@type': isRoot ? 'WebSite' : 'SearchResultsPage',
-    name: 'nosey',
-    alternateName: ['Nosey', 'nosquawks'],
-    about: 'A Nostr searcher',
-    url,
-  });
+  let { jsonLd }: Props = $props();
 </script>
 
 <!-- eslint-disable-next-line svelte/no-at-html-tags -->

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -2,24 +2,54 @@ import { describe, expect, it } from 'vitest';
 import { createSearchPageSeo } from './seo';
 
 describe('createSearchPageSeo', () => {
-  it('uses the site root for the initial page', () => {
+  it('uses the site root and default metadata for the initial page', () => {
     expect(createSearchPageSeo('', 0)).toEqual({
       isInitial: true,
       url: 'https://nosey.vercel.app',
+      title: 'nosey | A Nostr searcher',
+      description: 'A Nostr searcher',
+      keywords: 'nostr,search,notes,damus,snort',
+      ogTitle: 'nosey',
+      ogType: 'website',
+      ogSiteName: 'nosey',
+      ogImage: 'https://nosey.vercel.app/ogp.png',
+      twitterCard: 'summary',
+      twitterImage: 'https://nosey.vercel.app/favicon.png',
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: 'nosey',
+        alternateName: ['Nosey', 'nosquawks'],
+        about: 'A Nostr searcher',
+        url: 'https://nosey.vercel.app',
+      },
     });
   });
 
-  it('creates a canonical URL for a search query', () => {
-    expect(createSearchPageSeo('from:npub1abc', 0)).toEqual({
+  it('creates a canonical URL and title for a search query', () => {
+    const seo = createSearchPageSeo('from:npub1abc', 0);
+    expect(seo).toMatchObject({
       isInitial: false,
       url: 'https://nosey.vercel.app/?q=from%3Anpub1abc',
+      title: 'from:npub1abc - nosey',
+      ogTitle: 'from:npub1abc - nosey',
+      jsonLd: {
+        '@type': 'SearchResultsPage',
+        url: 'https://nosey.vercel.app/?q=from%3Anpub1abc',
+      },
     });
   });
 
-  it('includes a non-initial result page', () => {
-    expect(createSearchPageSeo('hello', 2)).toEqual({
+  it('includes a non-initial result page in the canonical URL', () => {
+    const seo = createSearchPageSeo('hello', 2);
+    expect(seo).toMatchObject({
       isInitial: false,
       url: 'https://nosey.vercel.app/?q=hello&page=2',
+      title: 'hello - nosey',
+      jsonLd: {
+        '@type': 'SearchResultsPage',
+        url: 'https://nosey.vercel.app/?q=hello&page=2',
+      },
     });
   });
 });

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,9 +1,11 @@
 const SITE_URL = 'https://nosey.vercel.app';
+const SITE_NAME = 'nosey';
+const SITE_DESCRIPTION = 'A Nostr searcher';
+const SITE_ALTERNATE_NAMES = ['Nosey', 'nosquawks'];
 
-export const createSearchPageSeo = (query: string, page: number) => {
-  const isInitial = query === '';
+const createUrl = (query: string, page: number, isInitial: boolean) => {
   if (isInitial) {
-    return { isInitial, url: SITE_URL };
+    return SITE_URL;
   }
 
   const params = new URLSearchParams({ q: query });
@@ -11,5 +13,32 @@ export const createSearchPageSeo = (query: string, page: number) => {
     params.set('page', page.toString());
   }
 
-  return { isInitial, url: `${SITE_URL}/?${params}` };
+  return `${SITE_URL}/?${params}`;
+};
+
+export const createSearchPageSeo = (query: string, page: number) => {
+  const isInitial = query === '';
+  const url = createUrl(query, page, isInitial);
+
+  return {
+    isInitial,
+    url,
+    title: isInitial ? 'nosey | A Nostr searcher' : `${query} - nosey`,
+    description: SITE_DESCRIPTION,
+    keywords: 'nostr,search,notes,damus,snort',
+    ogTitle: isInitial ? 'nosey' : `${query} - nosey`,
+    ogType: 'website',
+    ogSiteName: SITE_NAME,
+    ogImage: `${SITE_URL}/ogp.png`,
+    twitterCard: 'summary',
+    twitterImage: `${SITE_URL}/favicon.png`,
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': isInitial ? 'WebSite' : 'SearchResultsPage',
+      name: SITE_NAME,
+      alternateName: SITE_ALTERNATE_NAMES,
+      about: SITE_DESCRIPTION,
+      url,
+    },
+  };
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -53,23 +53,19 @@
 </script>
 
 <svelte:head>
-  {#if seo.isInitial}
-    <title>nosey | A Nostr searcher</title>
-  {:else}
-    <title>{q} - nosey</title>
-  {/if}
-  <meta name="description" content="A Nostr searcher" />
-  <meta name="keywords" content="nostr,search,notes,damus,snort" />
+  <title>{seo.title}</title>
+  <meta name="description" content={seo.description} />
+  <meta name="keywords" content={seo.keywords} />
   <meta property="og:url" content={seo.url} />
-  <meta property="og:title" content={seo.isInitial ? 'nosey' : `${q} - nosey`} />
-  <meta property="og:description" content="A Nostr searcher" />
-  <meta property="og:type" content="website" />
-  <meta property="og:site_name" content="nosey" />
-  <meta property="og:image" content="https://nosey.vercel.app/ogp.png" />
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:image" content="https://nosey.vercel.app/favicon.png" />
+  <meta property="og:title" content={seo.ogTitle} />
+  <meta property="og:description" content={seo.description} />
+  <meta property="og:type" content={seo.ogType} />
+  <meta property="og:site_name" content={seo.ogSiteName} />
+  <meta property="og:image" content={seo.ogImage} />
+  <meta name="twitter:card" content={seo.twitterCard} />
+  <meta name="twitter:image" content={seo.twitterImage} />
   <link rel="canonical" href={seo.url} />
-  <JsonLd url={seo.url} isRoot={seo.isInitial} />
+  <JsonLd jsonLd={seo.jsonLd} />
 </svelte:head>
 
 <form


### PR DESCRIPTION
## Summary
- `createSearchPageSeo` previously returned only `{ isInitial, url }`, while the title/meta description/OGP tags were assembled directly inline in `+page.svelte`'s `<svelte:head>` — a mismatch with what the "Seo" name implies.
- Expanded `createSearchPageSeo` to own the full set of page metadata (title, description, keywords, OGP fields, Twitter card fields, and the JSON-LD object), so `+page.svelte` now just renders `seo.*` values with no branching.
- `JsonLd.svelte` no longer re-derives `name`/`about`/`@type` from raw `url`/`isRoot` props (which duplicated values already owned by `seo.ts`); it now just takes a `jsonLd` object and serializes it.

## Test plan
- [x] `npx vitest run` — all tests pass, including updated `src/lib/seo.test.ts`
- [x] `npx svelte-check` — 0 errors
- [x] `npx biome check --error-on-warnings` on changed files