### PR TITLE
chore(ci): group fortawesome packages in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
+    groups:
+      fortawesome:
+        patterns:
+          - '@fortawesome/*'


### PR DESCRIPTION
## Summary
- Adds a Dependabot `groups` rule so all `@fortawesome/*` packages are bumped together in a single PR instead of separately.

## Why
#358 and #362 each bumped a single `@fortawesome/*` package to 7.3.1 independently, which broke `svelte-check` because these packages pin an exact (non-range) version of the shared `@fortawesome/fontawesome-common-types` dependency — bumping only one package leaves a mismatched nested copy. See #363 for the fix that bumps all three packages together; this change prevents the issue from recurring on future Dependabot updates.

## Test plan
- [x] `dependabot.yml` syntax matches the [grouped updates docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/customizing-dependency-updates#grouping-dependency-updates)