### PR TITLE
chore(deps): migrate to Skeleton v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.3",
-        "@skeletonlabs/skeleton": "^4.15.2",
-        "@skeletonlabs/skeleton-svelte": "^4.15.2",
+        "@skeletonlabs/skeleton": "^5.0.0",
+        "@skeletonlabs/skeleton-svelte": "^5.0.0",
         "@sveltejs/adapter-auto": "^7.0.1",
         "@sveltejs/kit": "^2.69.2",
         "@sveltejs/vite-plugin-svelte": "^7.2.0",
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
-      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/@skeletonlabs/skeleton": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-4.15.2.tgz",
-      "integrity": "sha512-5O23Py76nw56aoieV2b2T7MJ6xS0DwDjUULpwLnCXxXOnmzADEoWoQxb/ABbqg04IMOygtRzK3HO22I1+kFsog==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-5.0.0.tgz",
+      "integrity": "sha512-kcUU77eZTNdbz59FgCxIjimH1d9DkZtMU3+IT2yBxoFQczZGPkJ0xw97ecHeJfzBp8Ah16NqPOcxHjXxO77O9w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1293,51 +1293,54 @@
       }
     },
     "node_modules/@skeletonlabs/skeleton-common": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton-common/-/skeleton-common-4.15.2.tgz",
-      "integrity": "sha512-y7KZn++Av8UHdoeaaguQ7zIS1HlK7Y5jyPDnHy65wJ60iS97fMtQV0kGhqVoYCWhor+xrjbAFjWtaPOPPDEMYA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton-common/-/skeleton-common-5.0.0.tgz",
+      "integrity": "sha512-OzBf8nUsYMXPSo6FO2MSZ+pKzAN66Dro9Jis3Xf7sJRpbpzLU9sr4PSW9K9uDy4Z6/EiQPk7R9JMr0J633ft6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@skeletonlabs/skeleton-svelte": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton-svelte/-/skeleton-svelte-4.15.2.tgz",
-      "integrity": "sha512-vZkRhR701EOHVXVKh/NFRSY8D9LPBvmdNFdtfgqO7TEg77sypJUvERl2dxErTLY1QjVklVpjsHRCTaSLn+1Ntg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton-svelte/-/skeleton-svelte-5.0.0.tgz",
+      "integrity": "sha512-SuUX19bCFku8GF2kmLPFUTC1c7k8GeSSYJz4oJfa7Nb3LTIY+WDMWeGbwvMzfqyhV6s2XV3xefyf1joVHgzPAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@internationalized/date": "3.12.0",
-        "@skeletonlabs/skeleton-common": "4.15.2",
-        "@zag-js/accordion": "1.39.1",
-        "@zag-js/avatar": "1.39.1",
-        "@zag-js/carousel": "1.39.1",
-        "@zag-js/collapsible": "1.39.1",
-        "@zag-js/collection": "1.39.1",
-        "@zag-js/combobox": "1.39.1",
-        "@zag-js/date-picker": "1.39.1",
-        "@zag-js/dialog": "1.39.1",
-        "@zag-js/file-upload": "1.39.1",
-        "@zag-js/floating-panel": "1.39.1",
-        "@zag-js/listbox": "1.39.1",
-        "@zag-js/menu": "1.39.1",
-        "@zag-js/pagination": "1.39.1",
-        "@zag-js/popover": "1.39.1",
-        "@zag-js/progress": "1.39.1",
-        "@zag-js/radio-group": "1.39.1",
-        "@zag-js/rating-group": "1.39.1",
-        "@zag-js/slider": "1.39.1",
-        "@zag-js/steps": "1.39.1",
-        "@zag-js/svelte": "1.39.1",
-        "@zag-js/switch": "1.39.1",
-        "@zag-js/tabs": "1.39.1",
-        "@zag-js/tags-input": "1.39.1",
-        "@zag-js/toast": "1.39.1",
-        "@zag-js/toggle-group": "1.39.1",
-        "@zag-js/tooltip": "1.39.1",
-        "@zag-js/tree-view": "1.39.1"
+        "@internationalized/date": "3.12.2",
+        "@skeletonlabs/skeleton-common": "5.0.0",
+        "@zag-js/accordion": "1.42.0",
+        "@zag-js/avatar": "1.42.0",
+        "@zag-js/carousel": "1.42.0",
+        "@zag-js/collapsible": "1.42.0",
+        "@zag-js/collection": "1.42.0",
+        "@zag-js/combobox": "1.42.0",
+        "@zag-js/date-picker": "1.42.0",
+        "@zag-js/dialog": "1.42.0",
+        "@zag-js/file-upload": "1.42.0",
+        "@zag-js/floating-panel": "1.42.0",
+        "@zag-js/i18n-utils": "1.42.0",
+        "@zag-js/listbox": "1.42.0",
+        "@zag-js/marquee": "1.42.0",
+        "@zag-js/menu": "1.42.0",
+        "@zag-js/pagination": "1.42.0",
+        "@zag-js/popover": "1.42.0",
+        "@zag-js/progress": "1.42.0",
+        "@zag-js/qr-code": "1.42.0",
+        "@zag-js/radio-group": "1.42.0",
+        "@zag-js/rating-group": "1.42.0",
+        "@zag-js/slider": "1.42.0",
+        "@zag-js/steps": "1.42.0",
+        "@zag-js/svelte": "1.42.0",
+        "@zag-js/switch": "1.42.0",
+        "@zag-js/tabs": "1.42.0",
+        "@zag-js/tags-input": "1.42.0",
+        "@zag-js/toast": "1.42.0",
+        "@zag-js/toggle-group": "1.42.0",
+        "@zag-js/tooltip": "1.42.0",
+        "@zag-js/tree-view": "1.42.0"
       },
       "peerDependencies": {
-        "svelte": "^5.29.0"
+        "svelte": "^5.40.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -2104,154 +2107,154 @@
       }
     },
     "node_modules/@zag-js/accordion": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.39.1.tgz",
-      "integrity": "sha512-GA3m7gRTm3weSe1eMlHIsTNztcjZ6joIaRgxxKil7q/UX0xIVVGDy0aCr6oo7FAuoMiOOBVurYXILpFZ30nOXA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.42.0.tgz",
+      "integrity": "sha512-eTVh6Uz3CqdcJDr5mHWTT+oICSrZFfYCCxIpOKF00nADmb96nCDqOAYFMf8gM3J/4UDS/V27QzEH5GPmFWiHIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/anatomy": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.39.1.tgz",
-      "integrity": "sha512-p2iFAs2pVQgv5iCDAftA7g9Z/fUYXW94dRIGk415TSbkp/YDENydm/JtRoNctp302UIx4Eeuc5QBR+7h5kuISA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.42.0.tgz",
+      "integrity": "sha512-F6kRAPxgBZRZmuV5SLywcrGNSclKcAcPAAgSrEdr2Z2dzFgQngbvS4dmdQyGau/vtQ42OlCI48Ri4t0hZxXkMw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@zag-js/aria-hidden": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.39.1.tgz",
-      "integrity": "sha512-wiwcz3N086qBMEU3VKfHhcvGm6Jm1PIcDXys/jEqiKPtHoYZhDip0n0cPOoasss/A1oS39QFVdk3WpLXGu3Izw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.42.0.tgz",
+      "integrity": "sha512-ao1RyEbHbglJtLLR4sJLPiD3hWF1CacuN5eqvODh/7HcntWULrkUHo8DIdzYgFL9GUHDyDmpaechMX5wL3kdPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1"
+        "@zag-js/dom-query": "1.42.0"
       }
     },
     "node_modules/@zag-js/auto-resize": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/auto-resize/-/auto-resize-1.39.1.tgz",
-      "integrity": "sha512-ditIo9mW7fapq+4yx3/8hMpMZlWaoOy66EOzUz8dSVqnxnTWAjnTICu/9zFh8pkWerlzGTtDOJPP1oZ8S/rgVg==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/auto-resize/-/auto-resize-1.42.0.tgz",
+      "integrity": "sha512-iL7EI30VknEkVb8PhTcLkvR8aiZda0IwJGT4K0cb7J/fMxsDAGjnjdLRu+dGUPZsXji1n58wlaKjTtCQCaXfOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1"
+        "@zag-js/dom-query": "1.42.0"
       }
     },
     "node_modules/@zag-js/avatar": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/avatar/-/avatar-1.39.1.tgz",
-      "integrity": "sha512-LWrgJ0bebnXPSL+uehA9z6BlCD/MZEOQBJqH/F2QQFSAAZXUUDKtzVDmc+UtwjDsHXqqTghi+v2atQJHNMcJ2g==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/avatar/-/avatar-1.42.0.tgz",
+      "integrity": "sha512-rY2OxTTlvX1EMXENruejUUOZeiHusEpWLHNhrlqXMWMPWmcCe3aZ7iGMvjPFMb2mTMn0fzWmuY0nZDdVYk3V/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/carousel": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/carousel/-/carousel-1.39.1.tgz",
-      "integrity": "sha512-5z5z3IldUgZ/R+KZLNQDoJFNTXzYd28YOmgfWH61Vvyv+RarX8kwZW8ajW/fNiqcWXyhW3/VMU0lArrfjbQVtQ==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/carousel/-/carousel-1.42.0.tgz",
+      "integrity": "sha512-8VMPlg5DP8vye4ujyEqzM/EQ0osOVtoG3bUJ6CGWdRIdSkbgjIt1tY8DlS1WzOvSUMnTcTAi/RPxoxYZwTIhsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/scroll-snap": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/scroll-snap": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/collapsible": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.39.1.tgz",
-      "integrity": "sha512-Zgccg/t7M8i0JVwZPPgW7XB7kGhTO475hsmwkF/8CYLqBBckVDHUARp2we24hENCm/98eez6R0eDEmE+tldFWA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.42.0.tgz",
+      "integrity": "sha512-MSQo9qRwp2r6aj3G/lKd3gSXAAjuCaq1LtLT3BxHEQ5skn2NQWTKVgReUSuDJNl0Lz+Z5WYq5+5TCDHr4YKHRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/collection": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/collection/-/collection-1.39.1.tgz",
-      "integrity": "sha512-fyOyKmP7MRo0/U8mBmB7KgHRXHhXP27LCcasy3x+qTAQtuEfYG1EPhKuj07oBWlX/2qfcKYn2R3YopHcqFcCiA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/collection/-/collection-1.42.0.tgz",
+      "integrity": "sha512-+Bhj/2zqVVzmS788lsg/xK1ezksMc2pfVg2oO6MnipLCo8KrgzuuvhUahUzK+uIOc9ljBW4zl9Wcm3G248gh0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/combobox": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/combobox/-/combobox-1.39.1.tgz",
-      "integrity": "sha512-fmStpG+k4xrxCzqUX0ssnOMeoSietWm5ir3qmEZcagzNqNycAXMvOELAIeyXi87Kut6aDGhxLOV7o395HVXl/w==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/combobox/-/combobox-1.42.0.tgz",
+      "integrity": "sha512-fe+Sco278h8PPFM0g3eR5366/oVIfSI3B7qDXl/xmYKMQXhIp+bKxew3U0q1COSVof0x3wrIoIpY51BXj1McGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/collection": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dismissable": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/focus-visible": "1.39.1",
-        "@zag-js/live-region": "1.39.1",
-        "@zag-js/popper": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/collection": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dismissable": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/focus-visible": "1.42.0",
+        "@zag-js/live-region": "1.42.0",
+        "@zag-js/popper": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/core": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.39.1.tgz",
-      "integrity": "sha512-Yp0r49QLYXe2j7fgyAiilH4umXFydCnr5hcRDwJU+sxvUAlq00JQIJIEK2pT6k8cJiNNsFEV5WkOX7jsqpAX2A==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.42.0.tgz",
+      "integrity": "sha512-jE/sbpZvbD+/etbawzhL/L2lP1pPefed5d919je+K5h9b6GAK3lUThleaDUCww3bT53B1L7O5gtqBapW37N1ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/date-picker": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/date-picker/-/date-picker-1.39.1.tgz",
-      "integrity": "sha512-t9q1H0aZQJkbzKTR2Bn5vMwaoFoirxekiSxw8ju0F0vr4Kg4BJ9yueOQm5I2wALKnJbZu4Ua5MgzlrDF3CQt3A==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/date-picker/-/date-picker-1.42.0.tgz",
+      "integrity": "sha512-M8zt5kdOld7YKYmCZCQ8xPJ8+xwBpxIumzWgzFGoadSxYQPaK8gPqPFKxADJZWX7p/oHdpw2BVcVFWNC0urcyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/date-utils": "1.39.1",
-        "@zag-js/dismissable": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/live-region": "1.39.1",
-        "@zag-js/popper": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/date-utils": "1.42.0",
+        "@zag-js/dismissable": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/live-region": "1.42.0",
+        "@zag-js/popper": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       },
       "peerDependencies": {
         "@internationalized/date": ">=3.0.0"
       }
     },
     "node_modules/@zag-js/date-utils": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/date-utils/-/date-utils-1.39.1.tgz",
-      "integrity": "sha512-i4SvBhru2Yz/zsHT0XvyFhf4a+pAKYkWXeVfU0RvF2S6mPTfgaMFF9ZNPq5Sy8K31EtAa6AVXcybYaYnibn1FA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/date-utils/-/date-utils-1.42.0.tgz",
+      "integrity": "sha512-pjFahzgNGlIIbNQWaPY4RcFhMo+9d9nHj7FctmexXdQ6x4aByfD8bPCUKomO2MsMs0/2lRkACjqZeJwP4oivAw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2259,317 +2262,347 @@
       }
     },
     "node_modules/@zag-js/dialog": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-1.39.1.tgz",
-      "integrity": "sha512-q+HTmfuRDRZthln9mb7i52wdltQOZlw3+nw3a2uygEe9xuEtHBwUz31XJzkn2UWQqhAt7cC39OwykhNLKrfkqA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-1.42.0.tgz",
+      "integrity": "sha512-2KpLQASTjr2JUR0XvqsMueVo+AAPeanD9ShFCY/YKv2qp6WRHo1Ig/tRj6pInsSBiHFo7QXyAD4SDax6C0zDcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/aria-hidden": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dismissable": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/focus-trap": "1.39.1",
-        "@zag-js/remove-scroll": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/aria-hidden": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dismissable": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/focus-trap": "1.42.0",
+        "@zag-js/remove-scroll": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/dismissable": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.39.1.tgz",
-      "integrity": "sha512-7/soy93Ersd5qedhSL/+CDcZ9gNTQV0ooDcqKtM8b4IxwD4rgWwGsewJY+tbKmOqaZobwa0YcWV2+YGgI23ESw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.42.0.tgz",
+      "integrity": "sha512-Cx/FAQ2MuQy3kecdmswrFk94Zie1ieBa1Pnt/2ECI5FR914EJd3DwY9Krsmlrq4Z15Wm+pVtfLXgakDewVgsiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/interact-outside": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/interact-outside": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/dom-query": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.39.1.tgz",
-      "integrity": "sha512-k01aXeUWLyJfB61CODaXj4PLhYmVpnVMFrC+3nk/XCn1MW7my8L/8KVg0m4W8n+X9MhpaLWsZDmK/dwED/3qSw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.42.0.tgz",
+      "integrity": "sha512-JgCNfp7F+YNFNb7Xmt6rXQr3N3V9Mp+pFRvZ8j5BTC3/G8ZYj/enrgOcuVwPlXPBGtA7ysvjig2x1c0Uou/6kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/types": "1.39.1"
+        "@zag-js/types": "1.42.0"
       }
     },
     "node_modules/@zag-js/file-upload": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/file-upload/-/file-upload-1.39.1.tgz",
-      "integrity": "sha512-cErPOnPwPyneUXpelsfm75DKn0/4SI8aqQnlbrqo522PEqAQyDfDdBsqebGgKWG3F0A++kKFp9LO9A5zCrw5gA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/file-upload/-/file-upload-1.42.0.tgz",
+      "integrity": "sha512-1I8mCSh6fykHmTStuD9qS425vySOhBjFZfkqLG1J10IfGjz8KCoHcOEbZDHqbJa4/Yq0d+mrwHpOYPS6jYBimA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/file-utils": "1.39.1",
-        "@zag-js/i18n-utils": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/file-utils": "1.42.0",
+        "@zag-js/i18n-utils": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/file-utils": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/file-utils/-/file-utils-1.39.1.tgz",
-      "integrity": "sha512-ll/W5o74SMmoAS+l7PkmmGjPj4PLCSG/cwQh1Y/+LpaSev0YiR3Nk2OzRIIPtm3NivYVxKGawaCOf1RvT/82LQ==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/file-utils/-/file-utils-1.42.0.tgz",
+      "integrity": "sha512-goU5T/8SVpeoR33PS4kRWZkcfSERI7FVqqSn521PmxZ/wZMVDrXaivygbttGV8nCWfbwmsMqeyp2iy5MnbNovQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/i18n-utils": "1.39.1"
+        "@zag-js/i18n-utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/floating-panel": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/floating-panel/-/floating-panel-1.39.1.tgz",
-      "integrity": "sha512-IfPbf3pwJGqBWHec/rPzpdPjfMCLed59LlEophvRy49FEdksv8eN6nr9DXl2wWZEoQhH99scXfLMbtEZsPsFWg==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/floating-panel/-/floating-panel-1.42.0.tgz",
+      "integrity": "sha512-C1nUUgpkAex6QG7/5IkTu38ZBj4RMLbK3sNrssMoZ6kR60jB7D1Lz7D4NbD2b0dYabM6XH10TEaCzEPY8LpC3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/popper": "1.39.1",
-        "@zag-js/rect-utils": "1.39.1",
-        "@zag-js/store": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/popper": "1.42.0",
+        "@zag-js/rect-utils": "1.42.0",
+        "@zag-js/store": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/focus-trap": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.39.1.tgz",
-      "integrity": "sha512-2ZzVefHMotvtxUo/gP4R45Szw/EPaPkTKEHaug6/il62SPDbkFODF+5r1zXyLbLuwCHq0apvQasg/ONLihwlXw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.42.0.tgz",
+      "integrity": "sha512-47O/OpLUm9o8CZd3ez0ntAOUKZEQ1zFj7e86fpYuQ+fNtBlpYMFHQxMRftPkiU5Ysjrz5x8RYV8A8uJ9cboNig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1"
+        "@zag-js/dom-query": "1.42.0"
       }
     },
     "node_modules/@zag-js/focus-visible": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.39.1.tgz",
-      "integrity": "sha512-iEuTOYHE8HRn/7ULC9c9BTTWo0C0MJRCbYVxbh/d7v8qAuq4CS76pdfceNo3KeWbb968T+yiG6q0AjiHsr8IOw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.42.0.tgz",
+      "integrity": "sha512-zT1Fk+8m6x6hzoD5fOIEV4JQIX33pwkBzANqwruQwaSqkOYtI2FmsG71YHnzKvrBppG2okPrRHEMyZEgfshIcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1"
+        "@zag-js/dom-query": "1.42.0"
       }
     },
     "node_modules/@zag-js/i18n-utils": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/i18n-utils/-/i18n-utils-1.39.1.tgz",
-      "integrity": "sha512-TKRLQQlHgJ4cxsHo3tZPtbFjGu9m1UPtfezRGFKq7A8czhdqRhaCpaWF849cd6dI7x6rWvvTan858gOFpyANnQ==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/i18n-utils/-/i18n-utils-1.42.0.tgz",
+      "integrity": "sha512-uVw+Ua3apxaBCRcsfHOlXcRPDNygSGoJ6ivmK0UJaw5QikZLEBYr7grzXDwRvZrdk0j0sA9Hk/gg3GdSXkhI3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1"
+        "@zag-js/dom-query": "1.42.0"
       }
     },
     "node_modules/@zag-js/interact-outside": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.39.1.tgz",
-      "integrity": "sha512-LnSbA+txMsFmzNPn84QKH01x2yJv4At/eKHn6rT2PyxXkJQIh8PvCTS3zVz4Syw11cmhcXt2eRwhzx8yImV92w==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.42.0.tgz",
+      "integrity": "sha512-CNNT1OtASacXEst8NMWDGmDwkOQgVQ0Ahc2SpPjSBZoVpxQIfhZ9FoeqcggDX7Nvze7kl6/OwA7pPi5TGQTVZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/listbox": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/listbox/-/listbox-1.39.1.tgz",
-      "integrity": "sha512-Mz0UpdXobdTQTyjM+Avgi7pDVB2dKyaUHqw3TloeleQL3VwTqClclkwHXtLYYE+oXa0zOet37wI9mzfaYx9iZQ==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/listbox/-/listbox-1.42.0.tgz",
+      "integrity": "sha512-nt842jgTaBYTgkqu3y+4l88wpmoyesXkS+Bc3Uvuc7ze9IB04vicSiRi+vstYyA20s/EjOr2tR9Kq7dNoROLaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/collection": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/focus-visible": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/collection": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/focus-visible": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/live-region": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/live-region/-/live-region-1.39.1.tgz",
-      "integrity": "sha512-E7YNd0QGzJ2n1ZhnI2smv+klwifsNRf9QaDCx7quVJCVYywpupsBK4R25KN75S1z8XaK+jAy6HYKj8DIhYjYeg==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/live-region/-/live-region-1.42.0.tgz",
+      "integrity": "sha512-YFkytNxBJDQIndh7W+bWMN9P74qsnQkzqqLv6LtX/TiOYr1PnL0p54DMvWhE7hqYiCyyLscBM9nbA1foSoPIPg==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@zag-js/menu": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-1.39.1.tgz",
-      "integrity": "sha512-bRDGLGkiGhzNtORBXkbBQV/xp2zEkwpYIepfWCaUoFwKUmx7GGnShTBFxJyq0u2D4IkS9GOwcqm20EhMv6V+TA==",
+    "node_modules/@zag-js/marquee": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/marquee/-/marquee-1.42.0.tgz",
+      "integrity": "sha512-bTYbNFuDdKV7SyHchyCLhE+JtReO8VUaGfv9Prh3LfFq7yNEqiFngqhY7TZBw6Vok4q8msu0r9aAqOspZqHEHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dismissable": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/focus-visible": "1.39.1",
-        "@zag-js/popper": "1.39.1",
-        "@zag-js/rect-utils": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
+      }
+    },
+    "node_modules/@zag-js/menu": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-1.42.0.tgz",
+      "integrity": "sha512-Jg2q+FrHeZ2ZTxrz/TAnNelapN6IGtyCnBmoNbcHGcnf3gqnEjJpug3Fn6BmPQrmTNw0+q7hBmrESyncjrfbUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dismissable": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/focus-visible": "1.42.0",
+        "@zag-js/popper": "1.42.0",
+        "@zag-js/rect-utils": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/pagination": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-1.39.1.tgz",
-      "integrity": "sha512-3Q1B9/g3ajhvXjuGffJ7otyXcXK5+uhdbE5A9CZa4bsW3pf25L9Cp+ZAjdXQMDc8T4jhZJAKFmDJfQgtr1oEIw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-1.42.0.tgz",
+      "integrity": "sha512-QEcnc8z0U4RREOa1MVGFNbKJONLzbo5egdUppURkbAwhv+paR9ufG4uli7QlMvA3KgdfCHPM92+MhnYwutp5nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/popover": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.39.1.tgz",
-      "integrity": "sha512-aO3ExO/O7Sa3ovdozFI6SujhNOpYdCca4bImnAiovDL8DY8zN3UNQebu35IQvw9/aRsx9VKSJL1AqzJJUImFRw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.42.0.tgz",
+      "integrity": "sha512-4knrgFDeYlKqjyRfYPEUfpIRjsTvg4zY/C0i3sbdxNEWiOW30DzW+/8Igabb00bOabrtRuIHBejm0Jorgn5JIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/aria-hidden": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dismissable": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/focus-trap": "1.39.1",
-        "@zag-js/popper": "1.39.1",
-        "@zag-js/remove-scroll": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/aria-hidden": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dismissable": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/focus-trap": "1.42.0",
+        "@zag-js/popper": "1.42.0",
+        "@zag-js/remove-scroll": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/popper": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.39.1.tgz",
-      "integrity": "sha512-h0UMY2dXJNfM3OvMQ9t9LzlmwvpCgjloz2IvU1txY3r32UIy7ve1H70zkKagLtLRxFTuWmhumYUPULPo/6a1DA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.42.0.tgz",
+      "integrity": "sha512-hQvXzLen/hXCItww5tJT6+VLxnee8CpsX0FabIiHub/fKIB6OeHmS/lk+RnIII57bljdjLSus/KnT8Xlmj6tRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/progress": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/progress/-/progress-1.39.1.tgz",
-      "integrity": "sha512-1IHyOw8DqPs3YH149Oj7W9a5oEfY5pc9GAVOPGbzYxVK/W8d/NIjVxa565I3J5cDJ0s6z3FrMSXMWUwr1ML4tw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/progress/-/progress-1.42.0.tgz",
+      "integrity": "sha512-ZGex63fTJHy4or5N8fBUxiwqxBGd1Vr+OE0Bnm8+FAQNjJ5BtCLhIlmsIUS8aX2SrBR0j/tp8E0ss35/PNq29Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
+      }
+    },
+    "node_modules/@zag-js/qr-code": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/qr-code/-/qr-code-1.42.0.tgz",
+      "integrity": "sha512-X9cUPzJKI7aWrf8ie2jgaXlFFetJf1fdwhnWnP5rG8v3jrFe4tDA1n3z6HE4bXkluZv/2EL9cROglbz5WGB6/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0",
+        "proxy-memoize": "3.0.1",
+        "uqr": "0.1.3"
       }
     },
     "node_modules/@zag-js/radio-group": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/radio-group/-/radio-group-1.39.1.tgz",
-      "integrity": "sha512-+sC9xcAyY/GbY+8HpKlbPgSyOxBLUSB18s6fe6K1wdmyom4PM0nmhLouuxisbFZYHOyfQwAOMo+ainRENB2hzQ==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/radio-group/-/radio-group-1.42.0.tgz",
+      "integrity": "sha512-VtoN9/d3HCe/oumjdwKzv/KilF2aLzbt1IYpejXF7Cwat8xmqnCoxiA2PLjE9NfD97ZM7grng1YGcjqrWOWvuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/focus-visible": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/focus-visible": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/rating-group": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/rating-group/-/rating-group-1.39.1.tgz",
-      "integrity": "sha512-IfdxWmM+3zpztx/HcE3bWob72sZNb1+BzK4tSySLVyjeqs8OzLDzrCbKqt10DmibnNOvpbjbq4eX4P5hV9YN7Q==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/rating-group/-/rating-group-1.42.0.tgz",
+      "integrity": "sha512-0+OQ+iy0djWJBzWdH8pMn+ze88B0T4TdO3kJuHyG2fgJnVgmuGWkoKp8RtXSAv2CVqXfx+diivqF9ZmhNmzLQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/rect-utils": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.39.1.tgz",
-      "integrity": "sha512-5gJ0PzeUme76xTWG+4XythWgmGgDKV4XAxEUaB3KKDtXgjDHwtu7PwKLIzFtlaaSf/U23PY+RNVBVCYg1GmZog==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.42.0.tgz",
+      "integrity": "sha512-4hIvDZEPxYAqhiSNVkZtQLzd7dV7IAn7c5GdWnVVAYtJDD1Tn+v0TYkoPuGQMqLsdpNDwncw3baT3xq1+PQi+w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@zag-js/remove-scroll": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.39.1.tgz",
-      "integrity": "sha512-uZfPR3Gl9sQFo+tJ7kbuwsBhw+RIZwWFnMDgrz5LIwSNGN6hsyC4HGOxe29clkWQ2X2AjqqmEMETwgX7Jg+wxA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.42.0.tgz",
+      "integrity": "sha512-RP1SzQuVDk+np5knkEz/mRasLHZUbO6f3xgq4M2u4SQhpOe34uJybd+14f4ElBntAJQWVeMhohpW4n0pNUW6WQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1"
+        "@zag-js/dom-query": "1.42.0"
       }
     },
     "node_modules/@zag-js/scroll-snap": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/scroll-snap/-/scroll-snap-1.39.1.tgz",
-      "integrity": "sha512-AzCc8MAAVqkiK5Y0cJZ24OIBZDQrUmEexACMuR6M5yZmlcEbS0EA/d6Wq+LSR1JMVTD4B+UwcMj1D3vJQ90ZTw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/scroll-snap/-/scroll-snap-1.42.0.tgz",
+      "integrity": "sha512-gFc5LZvHa4lyCmlt5n6nODc77dGeOc+3sWQMK+20cm/VjYNCsUDjoHP2KO5tgqLJNjPrON+i0BN/QfJUfoNA7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/dom-query": "1.39.1"
+        "@zag-js/dom-query": "1.42.0"
       }
     },
     "node_modules/@zag-js/slider": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/slider/-/slider-1.39.1.tgz",
-      "integrity": "sha512-OEA9R7Ly5cw+6ANofnMpuHH3rAo8gZEnxy7iEwePu11pq2RCnt8DSj2V+uqU+dTq15Uup1LSzRgJfTnAC4Z85A==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/slider/-/slider-1.42.0.tgz",
+      "integrity": "sha512-bHTNGxM2H2oag5IbsfsV/OJegz4ic1Zs89Mvm+ryVzqOc0upJl0xMC/D/K8wnRJ8OPubNnldA+R4W8o+/4IU8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/steps": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/steps/-/steps-1.39.1.tgz",
-      "integrity": "sha512-DC6swMpwITTB0DyCSxlpWyPNSUN9ul9jz4N6aAyQ0L1IK/noF/YYTZRAcXNSRzN4iutO/2mFGGbwGq/oVf+gPA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/steps/-/steps-1.42.0.tgz",
+      "integrity": "sha512-IDJKk4zPhQjJv5fxAvOy+LRcdnim5rJjpUdEsWq0/aDiVZiddg3sXLgJ8dTGfv6e58AIjTlaz85xv21dldWKYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/store": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.39.1.tgz",
-      "integrity": "sha512-zFpwP4lhiBVD9987rwAfZNVa2/f/xx4mhbCE1EEw31zxLAozY2jONeJ3UzPP05VbzKlRHBcvkaXAJQQGegTwFA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.42.0.tgz",
+      "integrity": "sha512-qQ5LB+l2dR1rZFCsErn9PeSrOADjnsvDl1NreEN/AaKXw9RK0YiQDqaCh7ndqjjA72UAcrnzgXsS0AAqxCC+MQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2577,130 +2610,130 @@
       }
     },
     "node_modules/@zag-js/svelte": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/svelte/-/svelte-1.39.1.tgz",
-      "integrity": "sha512-ZOyZjyvjePZdrkNTy5fa92ijeeID9e+3LRGziKGIII3JSEvwfkG/Buf8W84N8VHFxi0G0GcKmgVCDgKHyGQYoQ==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/svelte/-/svelte-1.42.0.tgz",
+      "integrity": "sha512-24UesuYzeRA5blEQcAiWt5tWLG05NhiJ1WNHhwafmn5HFBRvlaU7J7VymIHE06cKMCThwy2YjSgq3b56e+f3VQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/core": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/core": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       },
       "peerDependencies": {
         "svelte": ">=5"
       }
     },
     "node_modules/@zag-js/switch": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/switch/-/switch-1.39.1.tgz",
-      "integrity": "sha512-ikeQ42c0vyyPLeyW9U0dvcqTV1Ekpx5jZ050R905HGJ2GeWE0uBGuHbMpTG5U6Pwb0a+TMzqAr+jMsquVTCwzg==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/switch/-/switch-1.42.0.tgz",
+      "integrity": "sha512-227GNBAz8mYSKVsHV6r4YA/1/0rtbrP2foygPligDOkWMsNP9cjnW1HwM/z3x54UPWLqKuZjsjD7LSuDhbxtBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/focus-visible": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/focus-visible": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/tabs": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.39.1.tgz",
-      "integrity": "sha512-P2RThO1gX9SFsNqrAGPsXJxrjn5YqP6MFs9mdExU+tzzZyVjJQADkAmh98C0eEaCb6HKLpJZ/17hrnLDhm1Tig==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.42.0.tgz",
+      "integrity": "sha512-O0qFmeneJHr85AUL/44mHQy8Cr/jCZzh55rTKz5sBoZxmk7PIGopsasNLnpyaZ34tOpcKnNEg96FdlZ4O1bjlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/tags-input": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/tags-input/-/tags-input-1.39.1.tgz",
-      "integrity": "sha512-tc0+bd9FiUJwa+wY2hSVVGHLIBC3C3rOZX/4zjchRMs1xgl92c1/tYbytXny7ABB8ZMHveG7MtgDppVF4VkwBg==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tags-input/-/tags-input-1.42.0.tgz",
+      "integrity": "sha512-+zGHcW1EeYCfxfngR4DXJEUWn6iKBoWkN2OnP4HrrWIAwk+0yTOQpwEd4UcCoUOo7CPtqwBmZp2Y92AMuAFA+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/auto-resize": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/interact-outside": "1.39.1",
-        "@zag-js/live-region": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/auto-resize": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/interact-outside": "1.42.0",
+        "@zag-js/live-region": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/toast": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/toast/-/toast-1.39.1.tgz",
-      "integrity": "sha512-K7ndEfBTKDds10iQKCQUmin74s6V4BEIypAIyQxs18gQB9TCn5+wff886JAzecIKPY97PDQHDKjYR71yzRC7/g==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/toast/-/toast-1.42.0.tgz",
+      "integrity": "sha512-8WLogVjJiCrvQ4hv9vQrcjaFJLFGtOCb/pnir7SjqR1RzbYHoPLj5ASbM9bbjpcgQQYr0GaLovP6beQW8kjBjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dismissable": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dismissable": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/toggle-group": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.39.1.tgz",
-      "integrity": "sha512-KS4Bo17foMKXVBhQjocRf4GQxMV4pMXclTo14IWjldaHs2HIrNJ0Ar0Ri+vo47BBKBNsXs4HuNvfbMdQj94wEA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.42.0.tgz",
+      "integrity": "sha512-lhsPcj115a646wxHgzSkhSW4IZFKw4pqRTHSL0e8vR4jgCRhGLBzE70S+EgYIj+000A05eB+or0PhX5zeMK5qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/tooltip": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-1.39.1.tgz",
-      "integrity": "sha512-IsxFj7l8kPciwIyYJWlmQ7mhXocbjXxLj3m9z099slYOF7lApA33/ndY32w9ptrI4/nUh2nldzw6eRfSpVnuOA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-1.42.0.tgz",
+      "integrity": "sha512-viRGjX2yxF317M2G2tYvPS7+ZS3osmE+iGm40ZPg0sciezSZW1l4ZFSQ56qyCJ8rTUKv3T1m0NPWYhqVoT3eoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/focus-visible": "1.39.1",
-        "@zag-js/popper": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/focus-visible": "1.42.0",
+        "@zag-js/popper": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/tree-view": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/tree-view/-/tree-view-1.39.1.tgz",
-      "integrity": "sha512-sm6qUZjO0OaqBqO5s55KU+l5p1wXfUVScoen7BYVoFBuROH7qAZJi8YMclGvnnlyV506i8Hk0qqWnLg0F38jCA==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tree-view/-/tree-view-1.42.0.tgz",
+      "integrity": "sha512-QXIfFgE7BbtB7cHXwi8Gu/9ezkOaeZ4XFAixoJttiOgnw3EIRZPqATRijh446SDPuqsFh9RSjC2zEe3vcFssZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@zag-js/anatomy": "1.39.1",
-        "@zag-js/collection": "1.39.1",
-        "@zag-js/core": "1.39.1",
-        "@zag-js/dom-query": "1.39.1",
-        "@zag-js/types": "1.39.1",
-        "@zag-js/utils": "1.39.1"
+        "@zag-js/anatomy": "1.42.0",
+        "@zag-js/collection": "1.42.0",
+        "@zag-js/core": "1.42.0",
+        "@zag-js/dom-query": "1.42.0",
+        "@zag-js/types": "1.42.0",
+        "@zag-js/utils": "1.42.0"
       }
     },
     "node_modules/@zag-js/types": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.39.1.tgz",
-      "integrity": "sha512-w3vVpgxmdJvMDvv19DXTtFI6kJL6TXw//U0Z1BAc3rnDA9orcB9Ryw4uMNvIzFA607CgssyJcWDaQ/M3yAcbJw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.42.0.tgz",
+      "integrity": "sha512-4ghao1wuLouepdYMheEYtyOlKpVsvL0Eg9tf//5VyAf7S9zC7cgGxD6ttGTlIMxqKqnAuxIMsYHG76qkb8tv1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2708,9 +2741,9 @@
       }
     },
     "node_modules/@zag-js/utils": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.39.1.tgz",
-      "integrity": "sha512-9k741cH7L655Ua3tedTkuMblcXVXVgCLTB9svp9oTjA7oatpOpYF4z43kgAQVjyThNXMJ7AvtO4C80ajQLTScg==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.42.0.tgz",
+      "integrity": "sha512-Km0r9hY+f6/oCJXrO4nqCIuo+4gTqbloD0V0q7B8Jq8qeWte7HN+YJSagVlk8tfADqFMRgEW4Rug0bYHzrGbVA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3991,6 +4024,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxy-memoize": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.1.tgz",
+      "integrity": "sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "^3.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4537,6 +4580,13 @@
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
       }
+    },
+    "node_modules/uqr": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.3.tgz",
+      "integrity": "sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.1.4",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",
-    "@skeletonlabs/skeleton": "^4.15.2",
-    "@skeletonlabs/skeleton-svelte": "^4.15.2",
+    "@skeletonlabs/skeleton": "^5.0.0",
+    "@skeletonlabs/skeleton-svelte": "^5.0.0",
     "@sveltejs/adapter-auto": "^7.0.1",
     "@sveltejs/kit": "^2.69.2",
     "@sveltejs/vite-plugin-svelte": "^7.2.0",

--- a/src/app.css
+++ b/src/app.css
@@ -5,15 +5,6 @@
 
 @plugin "@tailwindcss/forms";
 
-/* Windows Bugfix: https://github.com/skeletonlabs/skeleton/issues/3993 */
-.select,
-.input,
-.textarea,
-.field-group {
-  background-color: var(--color-surface-50-950);
-  color: var(--color-surface-950-50);
-}
-
 /* NOTE: no .dark class is ever applied in this app, so this keeps the
    previous (v3 darkMode: 'class') behavior of always rendering the
    light theme regardless of the OS color-scheme preference. */

--- a/src/app.css
+++ b/src/app.css
@@ -9,7 +9,7 @@
 .select,
 .input,
 .textarea,
-.input-group {
+.field-group {
   background-color: var(--color-surface-50-950);
   color: var(--color-surface-950-50);
 }

--- a/src/lib/components/MentionMenu.svelte
+++ b/src/lib/components/MentionMenu.svelte
@@ -103,7 +103,7 @@
               <span class="min-w-0 truncate">{resolveDisplayName(item)}</span>
               {#if item.profile.nip05}
                 <span class="min-w-0 shrink-[999] truncate flex items-center gap-1">
-                  <code class="code truncate">{resolveNip05Display(item)}</code>
+                  <code class="truncate">{resolveNip05Display(item)}</code>
                   <Nip05Badge pubkey={item.pubkey} nip05={resolveNip05Display(item)} />
                 </span>
               {/if}

--- a/src/lib/components/NoteListItem.svelte
+++ b/src/lib/components/NoteListItem.svelte
@@ -90,7 +90,7 @@
         <span class="font-bold truncate min-w-0">{nameOrPubkey}</span>
         {#if identified.profile.nip05}
           <span class="min-w-0 flex-1 truncate flex items-center gap-1">
-            <code class="code truncate overflow-x-hidden!">{resolveNip05Display(identified)}</code>
+            <code class="truncate overflow-x-hidden!">{resolveNip05Display(identified)}</code>
             <Nip05Badge pubkey={note.pubkey} nip05={resolveNip05Display(identified)} />
           </span>
         {/if}

--- a/src/lib/components/NoteListItemMenu.svelte
+++ b/src/lib/components/NoteListItemMenu.svelte
@@ -48,21 +48,21 @@
           onclick={() => copyToClipboardWithToast(npub, 'npub1')}
           class={itemClass}
         >
-          Copy <code class="code ml-1">npub1</code>
+          Copy <code class="ml-1">npub1</code>
         </Menu.Item>
         <Menu.Item
           value="copy-note-id"
           onclick={() => copyToClipboardWithToast(noteId, 'note1 id')}
           class={itemClass}
         >
-          Copy <code class="code mx-1">note1</code> id
+          Copy <code class="mx-1">note1</code> id
         </Menu.Item>
         <Menu.Item
           value="copy-nevent-id"
           onclick={() => copyToClipboardWithToast(nevent, 'nevent1 id')}
           class={itemClass}
         >
-          Copy <code class="code mx-1">nevent1</code> id
+          Copy <code class="mx-1">nevent1</code> id
         </Menu.Item>
         <Menu.Item
           value="copy-text"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -79,18 +79,18 @@
   {/if}
 
   <div class="relative w-full">
-    <div class="input-group grid-cols-[1fr_auto]">
+    <div class="field-group grid-cols-[1fr_auto] gap-0">
       <!-- svelte-ignore a11y_autofocus -->
       <input
         type="search"
-        class="ig-input"
+        class="input"
         value={q}
         aria-label="search"
         oninput={handleQuery}
         use:autocomplete={{ prefix: 'from:' }}
         autofocus
       />
-      <button type="submit" class="ig-btn preset-filled-primary-500">
+      <button type="submit" class="btn preset-filled-primary-500">
         <FontAwesomeIcon icon={faSearch} title="Search" class="w-4 inline" />
       </button>
     </div>
@@ -102,12 +102,12 @@
         <p><b>Tips:</b></p>
         <div>
           <p>
-            By using <code class="code">from:npub...</code> directive you can filter notes by author.
+            By using <code>from:npub...</code> directive you can filter notes by author.
           </p>
           <p>
-            And you can auto-complete npub by typing <code class="code">from:@</code>
+            And you can auto-complete npub by typing <code>from:@</code>
             (e.g.
-            <a href={`/?q=${encodeURI(mattnQuery)}`}><code class="code">from:@mattn</code></a>)
+            <a href={`/?q=${encodeURI(mattnQuery)}`}><code>from:@mattn</code></a>)
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Upgrade `@skeletonlabs/skeleton` and `@skeletonlabs/skeleton-svelte` from `4.15.2` to `5.0.0`, applying the official CLI migration (`input-group` → `field-group`, `ig-input` → `input`, `ig-btn` → `btn`)
- Restore the search form's connected look with `gap-0`, since v5's `field-group` has a default gap unlike v4's `input-group`
- Drop the now-obsolete `code` class from bare `<code>` tags (4 components + search page), since v5 styles standalone `<code>` by default
- Remove the Windows/Firefox `<select>` background workaround in `app.css` — fixed natively upstream in skeletonlabs/skeleton#4380 (closes #3993)

## Test plan
- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] Compared v4 vs v5 screenshots (real browser, Playwright) for home, search results, pagination, header "Advanced search" menu, note item menu, copy toast, and mention autocomplete popover — all visually identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)